### PR TITLE
Make terrain-edge move orders advance naturally

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,9 @@
-# ChonkCraft 0.1.1-beta14 — BNE Combat and Action Scheduling
+# ChonkCraft 0.1.1-beta15 -- Natural Shoreline and Terrain Movement
 
-- Recreated the Battle.net Edition attack-program boundaries that decide when melee damage, projectiles, and impact effects become authoritative, even when presentation callbacks arrive early or late.
-- Eliminated duplicate and delayed missiles by separating launch presentation from simulation ownership, preserving native constructor ordering, and matching the fixed-pool same-cycle impact cadence.
-- Corrected the final construction pulse: completed buildings now wait for Battle.net Edition's last completion interval before becoming available and contributing supply.
-- Recreated cooperative traffic refusal behavior so an attacking unit transfers into the native movement wait when its first heading is occupied, without restarting units already executing their movement program.
-- Reduced early mobile action-cursor mismatches by 98 percent across the authenticated campaign evidence while preserving the accepted 52-campaign frontier with zero regressions or failed fixtures.
-- Strengthened semantic parity evidence to compare exact action cursors, facing, and order points, making future scheduling differences visible instead of treating related action families as equivalent.
-- Added focused regressions for melee timing, projectile preparation and impact cadence, construction completion, movement refusal, and semantic trace fidelity.
-- Verified the full Java engine suite against the previous public baseline: the exact pre-existing failure set is unchanged, with five additional passing tests.
+- Recreated Battle.net Edition's widening move-order behavior: ships ordered onto shoreline now sail to the closest legal water instead of acknowledging the command and remaining stationary.
+- Ground units ordered toward water, trees, or other incompatible terrain now approach the nearest reachable edge, including orders issued through the minimap.
+- Preserved the native distinction for genuinely disconnected destinations, which remain safely bounded and eventually stop without crossing illegal terrain.
+- Restricted an autonomous-critter terrain guard that had accidentally cancelled ordinary player movement before the pathfinder could apply the retail rule.
+- Strengthened the authenticated movement referee from 87 to 88 checks, with explicit behavioral proof for ships approaching land, soldiers approaching water, and soldiers approaching dense forest.
+- Verified all 52 authenticated campaign fixtures with zero failures and zero regressions against the accepted h40 frontier.
+- Verified the complete engine failure set is identical before and after the change, while the new player-facing movement tests pass.

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetMovementSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetMovementSystem.java
@@ -216,9 +216,13 @@ final class BattleNetMovementSystem {
             boolean firstConstructorResume = critter
                     && unit.battleNetConstructorBurnAfterCycle() > 0
                     && unit.battleNetIdlePhase() < 2;
-            if (!critter || (firstConstructorResume
+            // Ordinary player moves must reach the pathfinder below. It widens
+            // Range until a ship aimed at land, or a soldier aimed at trees,
+            // reaches the closest legal edge. This guard used to include every
+            // non-critter and silently finish those acknowledged orders here.
+            if (critter && firstConstructorResume
                     && !world.battleNetCritterCoastGoal(
-                            unit.orderTargetX(), unit.orderTargetY()))) {
+                            unit.orderTargetX(), unit.orderTargetY())) {
                 resetDisplacement(unit);
                 unit.clearPath();
                 world.finishOrder(unit);

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/NavalAirTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/NavalAirTest.java
@@ -165,22 +165,65 @@ class NavalAirTest {
         // other way round -- the order refused outright -- which reads better
         // on a click and is not what the game does.
         assertTrue(world.orderMove(ship, 5, 5), "the order is taken, as upstream takes it");
+        int shipStartDistance = Math.abs(ship.tileX() - 5);
         for (int cycle = 0; cycle < World.CYCLES_PER_SECOND * 20; cycle++) {
             world.tick();
             assertTrue(world.map().field(ship.tileX(), ship.tileY())
                             .hasFlag(TileFlag.WATER_ALLOWED | TileFlag.COAST_ALLOWED),
                     "a destroyer sailed up the shore to " + ship.tileX() + "," + ship.tileY());
         }
+        assertTrue(Math.abs(ship.tileX() - 5) < shipStartDistance,
+                "a destroyer ordered onto land must sail toward the closest legal water");
+        assertEquals(15, ship.tileX(),
+                "the destroyer must stop at the water edge nearest its land destination");
         assertTrue(world.orderMove(ship, 25, 20), "but should move freely at sea");
 
         assertTrue(world.orderMove(soldier, 25, 5), "the order is taken");
+        int soldierStartDistance = Math.abs(soldier.tileX() - 25);
         for (int cycle = 0; cycle < World.CYCLES_PER_SECOND * 20; cycle++) {
             world.tick();
             assertTrue(world.map().field(soldier.tileX(), soldier.tileY())
                             .hasFlag(TileFlag.LAND_ALLOWED | TileFlag.COAST_ALLOWED),
                     "a footman walked onto water at " + soldier.tileX() + "," + soldier.tileY());
         }
+        assertTrue(Math.abs(soldier.tileX() - 25) < soldierStartDistance,
+                "a footman ordered onto water must walk toward the closest legal shore");
+        assertEquals(14, soldier.tileX(),
+                "the footman must stop at the land edge nearest its water destination");
         assertTrue(world.orderMove(soldier, 10, 20));
+    }
+
+    @Test
+    void aMoveIntoTreesApproachesTheClosestWalkableEdge() {
+        GameMap map = new GameMap(20, 20, new Tileset());
+        for (int y = 0; y < 20; y++) {
+            for (int x = 0; x < 20; x++) {
+                map.field(x, y).setFlags(TileFlag.LAND_ALLOWED);
+            }
+        }
+        for (int y = 9; y <= 11; y++) {
+            for (int x = 10; x <= 12; x++) {
+                map.field(x, y).setFlags(TileFlag.FOREST | TileFlag.UNPASSABLE);
+            }
+        }
+        World world = new World(map, twoPlayers());
+        Unit soldier = world.createUnit(footman(), 0, 2, 10);
+
+        assertTrue(world.orderMove(soldier, 11, 10),
+                "the move into the forest must be accepted before route planning");
+        for (int cycle = 0; cycle < 600 && soldier.order() != Unit.Order.STILL; cycle++) {
+            world.tick();
+        }
+
+        assertEquals(Unit.Order.STILL, soldier.order(), "the forest approach never settled");
+        assertTrue(soldier.tileX() > 2,
+                "the footman acknowledged a forest-edge move but never approached it");
+        assertTrue(world.map().field(soldier.tileX(), soldier.tileY())
+                        .hasFlag(TileFlag.LAND_ALLOWED),
+                "the footman stopped on the forest instead of beside it");
+        assertEquals(2, Math.max(Math.abs(soldier.tileX() - 11),
+                        Math.abs(soldier.tileY() - 10)),
+                "the footman did not stop at the closest reachable edge of the tree block");
     }
 
     @Test

--- a/scripts/check-bne-movement-gate.sh
+++ b/scripts/check-bne-movement-gate.sh
@@ -41,12 +41,12 @@ for report in root.glob("TEST-*.xml"):
     failures += int(suite.attrib.get("failures", 0))
     errors += int(suite.attrib.get("errors", 0))
 missing = names - seen
-if missing or tests != 87 or skipped or failures or errors:
+if missing or tests != 88 or skipped or failures or errors:
     raise SystemExit(
-        f"movement referee: expected 87/0/0/0 with every class present; "
+        f"movement referee: expected 88/0/0/0 with every class present; "
         f"got {tests}/{skipped}/{failures}/{errors}, missing={sorted(missing)}"
     )
-print("movement edge referee: 87 pass, 0 skipped")
+print("movement edge referee: 88 pass, 0 skipped")
 PY
 
 echo "movement gate passed: large footprints, congestion and refusal recovery"


### PR DESCRIPTION
## What changed

- Let ordinary ship and ground move orders reach BNE's widening pathfinder when the exact clicked terrain is incompatible.
- Keep the early terrain cancellation restricted to the autonomous critter constructor case it models.
- Strengthen movement tests so stationary ships and soldiers can no longer pass merely by avoiding illegal terrain.
- Publish beta15 release notes for shoreline, forest-edge, and minimap movement.

## Root cause and player impact

The UI correctly acknowledged a move before route planning, but an over-broad critter guard ended every ordinary move whose exact destination tile was illegal for that movement class. Ships clicked on shoreline and soldiers clicked on trees or water therefore said they accepted the order and did nothing. BNE widens the permitted arrival range until the closest legal edge is reachable.

## Verification

- Clean ten-module Java reactor build: PASS.
- Authenticated movement referee: 88 pass, 0 skipped.
- Solid-wall unreachable control: PASS.
- Minimap command delivery with authenticated BNE pack: PASS.
- Complete authenticated 52-case regression gate: PASS, zero failed and zero regressions at accepted h40.
- Full engine suite comparison: exact same 106 pre-existing failures before and after, plus the new passing movement test.
- Documentation gate and diff checks: PASS.
- Local interactive playtest: confirmed working by the reporter.
