### PR TITLE
Make shoreline construction reach its foundation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,8 @@
-# ChonkCraft 0.1.1-beta15 -- Natural Shoreline and Terrain Movement
+# ChonkCraft 0.1.1-beta16 -- Reliable Shoreline Construction
 
-- Recreated Battle.net Edition's widening move-order behavior: ships ordered onto shoreline now sail to the closest legal water instead of acknowledging the command and remaining stationary.
-- Ground units ordered toward water, trees, or other incompatible terrain now approach the nearest reachable edge, including orders issued through the minimap.
-- Preserved the native distinction for genuinely disconnected destinations, which remain safely bounded and eventually stop without crossing illegal terrain.
-- Restricted an autonomous-critter terrain guard that had accidentally cancelled ordinary player movement before the pathfinder could apply the retail rule.
-- Strengthened the authenticated movement referee from 87 to 88 checks, with explicit behavioral proof for ships approaching land, soldiers approaching water, and soldiers approaching dense forest.
-- Verified all 52 authenticated campaign fixtures with zero failures and zero regressions against the accepted h40 frontier.
-- Verified the complete engine failure set is identical before and after the change, while the new player-facing movement tests pass.
+- Fixed accepted shipyard orders that sent a peasant to the coast, acknowledged the command, and then waited forever without laying a foundation.
+- Restored Battle.net Edition's ranged construction arrival rule: a land worker raising a shore building finishes beside its legal footprint instead of being required to enter water.
+- Applied the correction to the shared construction state machine so shipyards, foundries, refineries, and future ranged construction use one coherent rule rather than building-specific exceptions.
+- Added an end-to-end behavioral referee that starts with an accepted green shoreline placement, advances the worker through the normal order stream, and requires the shipyard foundation to appear.
+- Passed 48 focused construction, production, tanker, and oil-platform checks with zero failures and zero skips.
+- Verified all 52 authenticated campaign fixtures through 200 cycles with zero failures and zero regressions against the accepted h40 frontier.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,5 +265,5 @@ separate machines. It runs between processes on one machine and the lockstep and
 sync-hash machinery is tested, but nobody has recorded a two-machine game.
 
 The test suite is **2,165 tests**. On a fully configured machine 17 skip; with
-no external inputs 702 do. Both numbers matter and the difference between them is the
+no external inputs 703 do. Both numbers matter and the difference between them is the
 subject of [ci.md](ci.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,7 +16,7 @@ green Maven run meant anything.
 **This suite does not fail when its inputs are missing.** Tests that need the
 1995 Warcraft II data, an asset pack or the Opus vectors call
 `Assumptions.assumeTrue(...)` and skip, and Maven reports `BUILD SUCCESS`
-either way. With nothing configured, 702 of 2,165 tests skip and
+either way. With nothing configured, 703 of 2,167 tests skip and
 the run takes 25 seconds.
 
 So the exit code certifies almost nothing on its own, and a CI job that trusts
@@ -83,12 +83,12 @@ Per module and in total:
 The asymmetry is deliberate. Adding a test that always runs raises the run count
 and needs no change here. Adding a test that skips without game data raises the
 skip count and turns CI red until somebody writes the new number down. That
-second case is the one worth catching: it is how 702 tests came to be skippable
+second case is the one worth catching: it is how 703 tests came to be skippable
 in the first place, one at a time, with nothing objecting.
 
 | Profile | Inputs | Skips |
 |---|---|---|
-| `data-free` | none | 702 |
+| `data-free` | none | 703 |
 | `full` | installation, pack, Opus vectors | 17 |
 
 The seventeen that skip even in `full` want nothing anyone should have to

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetConstructionSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetConstructionSystem.java
@@ -1194,8 +1194,13 @@ final class BattleNetConstructionSystem {
         // laid one final S route and founded five cycles later.  Treating the
         // first footprint square as arrival founded immediately and made the
         // AI look as though it had issued the build early.
-        boolean exactPointArrival = !what.builderOutside()
-                && what.onTopRule() == null
+        // A fixed point is the finish only for a builder that can enter the
+        // footprint.  Shore buildings give a land worker range one -- the
+        // retail "peon won't dive" arm above -- so insisting on the stored
+        // point inside their water squares accepts the green placement, walks
+        // to the beach, and then waits there forever.  The same distinction
+        // applies to every ranged construction goal, not just shipyards.
+        boolean exactPointArrival = reach == 0
                 && worker.buildGoalX() >= 0 && worker.buildGoalY() >= 0;
         boolean atSite = exactPointArrival
                 ? worker.tileX() == worker.buildGoalX()

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/ShoreBuildingTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/ShoreBuildingTest.java
@@ -9,6 +9,7 @@ import net.chonkbase.chonkcraft.data.source.AssetSource;
 import net.chonkbase.chonkcraft.engine.map.GameMap;
 import net.chonkbase.chonkcraft.engine.map.TileFlag;
 import net.chonkbase.chonkcraft.engine.map.Tileset;
+import net.chonkbase.chonkcraft.engine.unit.Unit;
 import net.chonkbase.chonkcraft.engine.unit.UnitType;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
@@ -107,5 +108,35 @@ class ShoreBuildingTest {
         assertFalse(world.canPlaceBuilding(barracks, 5, 10),
                 "a barracks was built on the coast ribbon, which upstream blocks for"
                         + " everything that is not a shore building");
+    }
+
+    @Test
+    @DisplayName("an accepted shipyard order reaches a shoreline foundation")
+    void anAcceptedShipyardOrderReachesAFoundation() {
+        GameData data = load();
+        World world = shore(data);
+        UnitType workerType = data.unitTypes().types().get("unit-peasant");
+        UnitType yard = data.unitTypes().types().get("unit-human-shipyard");
+        assertNotNull(workerType);
+        assertNotNull(yard);
+        world.player(0).set(UnitType.Resource.GOLD, 10_000);
+        world.player(0).set(UnitType.Resource.WOOD, 10_000);
+        Unit worker = world.createUnit(workerType, 0, 5, 14);
+        int siteY = 10 - (Math.max(1, yard.tileHeight()) - 1);
+
+        assertTrue(world.orderBuild(worker, yard, 5, siteY),
+                "the green shoreline site was not accepted");
+        Unit foundation = null;
+        for (int cycle = 0; cycle < 4_000 && foundation == null; cycle++) {
+            world.tick();
+            for (Unit unit : world.units()) {
+                if (unit.type() == yard && unit.tileX() == 5 && unit.tileY() == siteY) {
+                    foundation = unit;
+                    break;
+                }
+            }
+        }
+        assertNotNull(foundation,
+                "the accepted shipyard order never laid its shoreline foundation");
     }
 }

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,8 +9,8 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. Measured on one commit, on one
 machine, the difference is:
 
-    authenticated inputs       2165 tests,  17 skipped
-    no external input          2165 tests, 702 skipped
+    authenticated inputs       2167 tests,  17 skipped
+    no external input          2167 tests, 703 skipped
 
 Both can be green.
 
@@ -130,7 +130,10 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 3),
         "launcher": (46, 0),
         "matchmaking": (2, 0),
-        "engine": (1331, 418),
+        # ShoreBuildingTest's accepted-order referee deliberately needs the
+        # authenticated pack whose shipyard and worker definitions it drives.
+        # It skips in this profile and runs in the full one.
+        "engine": (1333, 419),
         "desktop": (287, 231),
         "matchmaker-server": (4, 0),
     },
@@ -171,7 +174,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (46, 0),
         "matchmaking": (2, 0),
-        "engine": (1331, 2),
+        "engine": (1333, 2),
         "desktop": (287, 6),
         "matchmaker-server": (4, 0),
     },


### PR DESCRIPTION
## What changed

- use BNE ranged construction arrival for builders that cannot enter a footprint
- add an accepted green-placement-to-foundation shipyard referee
- publish beta16 release notes

## Root cause

The preview and command acceptance correctly approved the shoreline footprint, but the later build walker required the peasant to reach the fixed point inside the shipyard water footprint. The peasant reached the legal coast position and then waited forever.

## Validation

- focused test fails on the released code and passes with the correction
- 48 construction, production, tanker, and oil-platform tests: 48 passed, zero skipped
- authenticated 52-case campaign survey through 200 cycles: PASS, zero failures and zero regressions against h40
- documentation and diff gates pass
