### PR TITLE
Restore attack-march damage delivery

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,7 @@
-# ChonkCraft 0.1.1-beta17 -- Deeper Battle.net Edition Convergence
+# ChonkCraft 0.1.1-beta18 -- Reliable Attack-March Combat
 
-- Corrected route ownership when allied chasers meet at a drained movement boundary, advancing XHuman 10's first divergence from cycle 41 to 54 without weakening the standing-blocker behavior.
-- Restored the retail melee route-to-attack handoff: a fighter whose final route heading reaches its occupied quarry attacks immediately instead of serving an invented 23-cycle collision wait.
-- Moved XHuman 9's first skeleton strike from cycle 81 to the Battle.net Edition cycle 55; its next difference is now a separate defensive reaction.
-- Fixed replacement AI construction orders inheriting a failed order's completion flag, preventing a correctly reissued farm from erasing itself and sending its worker back to lumber.
-- Advanced XHuman 2's first coarse divergence from cycle 58 to 82 and made its player economy exact through cycle 200.
-- Improved the 52-campaign cycle-200 survey from 4 clean fixtures to 19 clean fixtures with zero regressions and promoted the authenticated common frontier to cycle 41.
-- Reached 98.453% agreement across 1,369,366 paired unit-cycles and 99.543% agreement across 1,338,052 comparable route decisions.
+- Fixed enemy units reaching a target under an attack-march order, visibly swinging, and then dealing no damage.
+- Unified commanded attacks and attack-march combat around Battle.net Edition's native attack program while preserving the march destination.
+- Repaired the stalled orc grunt versus ballista encounter captured in the Human 6 save: the first hit now lands after 13 cycles and repeats on the retail 25-cycle cadence.
+- Added authenticated Human 6 coverage that uses the original mission data and prevents this combat deadlock from returning.
+- Preserved all 52 campaign parity results with zero regressions and retained the accepted common frontier at cycle 41.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,6 @@ What is **unverified** rather than done: multiplayer between two physically
 separate machines. It runs between processes on one machine and the lockstep and
 sync-hash machinery is tested, but nobody has recorded a two-machine game.
 
-The test suite is **2,165 tests**. On a fully configured machine 17 skip; with
-no external inputs 703 do. Both numbers matter and the difference between them is the
+The test suite is **2,177 tests**. On a fully configured machine 17 skip; with
+no external inputs 709 do. Both numbers matter and the difference between them is the
 subject of [ci.md](ci.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,7 +16,7 @@ green Maven run meant anything.
 **This suite does not fail when its inputs are missing.** Tests that need the
 1995 Warcraft II data, an asset pack or the Opus vectors call
 `Assumptions.assumeTrue(...)` and skip, and Maven reports `BUILD SUCCESS`
-either way. With nothing configured, 703 of 2,167 tests skip and
+either way. With nothing configured, 709 of 2,177 tests skip and
 the run takes 25 seconds.
 
 So the exit code certifies almost nothing on its own, and a CI job that trusts
@@ -57,7 +57,7 @@ anything subtler.
 
 ### Authenticated data -- private self-hosted inputs
 
-Asserts the `full` profile: **17 skips of 2,165**, re-measured after the native
+Asserts the `full` profile: **17 skips of 2,177**, re-measured after the native
 runtime and multiplayer-service additions
 against a real 1995 installation. One of the seventeen depends on which release
 the installation is -- a Battle.net Edition sees 16, which is correct and not a
@@ -83,12 +83,12 @@ Per module and in total:
 The asymmetry is deliberate. Adding a test that always runs raises the run count
 and needs no change here. Adding a test that skips without game data raises the
 skip count and turns CI red until somebody writes the new number down. That
-second case is the one worth catching: it is how 703 tests came to be skippable
+second case is the one worth catching: it is how 709 tests came to be skippable
 in the first place, one at a time, with nothing objecting.
 
 | Profile | Inputs | Skips |
 |---|---|---|
-| `data-free` | none | 703 |
+| `data-free` | none | 709 |
 | `full` | installation, pack, Opus vectors | 17 |
 
 The seventeen that skip even in `full` want nothing anyone should have to

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetCombatSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetCombatSystem.java
@@ -2368,6 +2368,16 @@ final class BattleNetCombatSystem {
      * changes.
      */
     void stepAttackMove(Unit unit) {
+        // Retail's commanded attack, attack-march and opportunistic march all
+        // execute the same COrder_Attack animation program.  The Java order
+        // enum separates ATTACK_MOVE so it can retain its destination, but
+        // that separation must stop at dispatch: otherwise presentation can
+        // swing while script.bin's opcode-ten cursor never advances, leaving
+        // the pending melee blow permanently unresolved.  Human 6's adjacent
+        // grunt and ballista are the player-visible witness.
+        if (stepBattleNetAttackSequence(unit)) {
+            return;
+        }
         String attackStateTrace = System.getenv("CHONKCRAFT_TRACE_ATTACKSTATE");
         if (attackStateTrace != null
                 && unit.id() == Integer.parseInt(attackStateTrace)) {

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/BattleNetAttackMoveSequenceRealDataTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/BattleNetAttackMoveSequenceRealDataTest.java
@@ -1,0 +1,48 @@
+package net.chonkbase.chonkcraft.engine;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.chonkbase.chonkcraft.data.source.AssetSource;
+import net.chonkbase.chonkcraft.engine.campaign.Mission;
+import net.chonkbase.chonkcraft.engine.unit.Unit;
+import net.chonkbase.chonkcraft.engine.unit.UnitType;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/** Retail-data coverage for an attack-march that reaches a melee victim. */
+class BattleNetAttackMoveSequenceRealDataTest {
+
+    @Test
+    void attackMoveRunsTheNativeAttackProgramAfterReachingItsTarget() {
+        AssetSource assets = AssetSource.fromEnvironment();
+        Assumptions.assumeTrue(assets != null,
+                "No asset pack/install. Set -Dchonkcraft.pack=... or wc2.install.dir");
+
+        GameData data = new GameData(assets);
+        Mission mission = data.loadMission("campaigns/human/level06h");
+        assertNotNull(mission, "the retail Human 6 mission is missing");
+        World world = mission.world();
+        for (Unit unit : new java.util.ArrayList<>(world.units())) {
+            world.remove(unit);
+        }
+
+        UnitType gruntType = data.unitTypes().types().get("unit-grunt");
+        UnitType ballistaType = data.unitTypes().types().get("unit-ballista");
+        assertNotNull(gruntType);
+        assertNotNull(ballistaType);
+        Unit grunt = world.createUnit(gruntType, 5, 40, 61);
+        Unit ballista = world.createUnit(ballistaType, 1, 41, 61);
+        assertNotNull(grunt);
+        assertNotNull(ballista);
+
+        assertTrue(world.orderAttackMove(grunt, ballista.tileX(), ballista.tileY()));
+        int initialHealth = ballista.hitPoints();
+        for (int cycle = 0; cycle < 180 && ballista.hitPoints() == initialHealth; cycle++) {
+            world.tick();
+        }
+
+        assertTrue(ballista.hitPoints() < initialHealth,
+                "the adjacent attack-march visibly swung but never delivered BNE opcode-10 damage");
+    }
+}

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -5,7 +5,7 @@
 #
 # It exists because the suite skips rather than fails when its external inputs
 # are missing, so an unconfigured machine gets BUILD SUCCESS out of a run that
-# verified almost nothing. 699 of 2160 tests skip that way. This prints the
+# verified almost nothing. 709 of 2177 tests skip that way. This prints the
 # difference before you spend twenty-five seconds wondering why the run was
 # fast.
 #
@@ -208,7 +208,7 @@ head2 "What a test run would exercise"
 
 if [[ "$wc2_ok" == 1 && "$pack_ok" == 1 && "$opus_ok" == 1 ]]; then
     printf '  All three external inputs are configured.\n'
-    printf '  Expect 2160 tests, 17 skipped, and about four minutes of wall time.\n'
+    printf '  Expect 2177 tests, 17 skipped, and about four minutes of wall time.\n'
     printf '  Seven of the 17 need a display; five need a music fixture nobody is\n'
     printf '  asked to have (-Dopus.music); four are fixture-sensitive skips in\n'
     printf '  FacingCount, AutoAttack, AutoCastToggle and CommandSinkGuard. The\n'
@@ -228,7 +228,7 @@ elif [[ "$wc2_ok" == 1 ]]; then
 else
     printf '  At least one external input is missing.\n'
     printf '  The suite will still report BUILD SUCCESS, having skipped most of itself:\n'
-    printf '  with no input at all, 699 of 2160 tests skip and the run takes 25 seconds.\n'
+    printf '  with no input at all, 709 of 2177 tests skip and the run takes 25 seconds.\n'
     printf '  That is not a passing run. See docs/development-setup.md.\n'
 fi
 

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,8 +9,8 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. Measured on one commit, on one
 machine, the difference is:
 
-    authenticated inputs       2167 tests,  17 skipped
-    no external input          2167 tests, 703 skipped
+    authenticated inputs       2177 tests,  17 skipped
+    no external input          2177 tests, 709 skipped
 
 Both can be green.
 
@@ -133,9 +133,9 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # ShoreBuildingTest's accepted-order referee and the authenticated
         # attack-program lifecycle referees deliberately need the retail data
         # or derived pack they drive. They skip here and run in the full
-        # profile. The August 12 convergence work added nine engine tests;
-        # five are authenticated-data referees and four are hermetic.
-        "engine": (1342, 424),
+        # profile. The August 12 convergence work added ten engine tests;
+        # six are authenticated-data referees and four are hermetic.
+        "engine": (1343, 425),
         "desktop": (287, 231),
         "matchmaker-server": (4, 0),
     },
@@ -176,7 +176,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (46, 0),
         "matchmaking": (2, 0),
-        "engine": (1342, 2),
+        "engine": (1343, 2),
         "desktop": (287, 6),
         "matchmaker-server": (4, 0),
     },


### PR DESCRIPTION
## What changed

- runs Battle.net Edition native attack sequencing for ATTACK_MOVE as well as ATTACK
- adds authenticated Human 6 coverage for the stalled grunt-versus-ballista encounter
- prepares 0.1.1-beta18 release notes

## Root cause

ATTACK_MOVE displayed its swing animation but did not advance the native attack program, leaving opcode-10 melee damage pending forever.

## Verification

- exact save replay: first hit after 13 cycles, then every 25 cycles
- focused authenticated combat suite passes
- 52-case BNE survey: zero regressions, common frontier remains cycle 41
- broad engine failure set is identical to the accepted baseline
- source, native-runtime, comment provenance, documentation, and BNE readiness checks pass