### PR TITLE
Fix phantom projectiles and coastal attacks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
-# ChonkCraft 0.1.1-beta18 -- Reliable Attack-March Combat
+# ChonkCraft 0.1.1-beta19 -- Reliable Siege and Naval Fire
 
-- Fixed enemy units reaching a target under an attack-march order, visibly swinging, and then dealing no damage.
-- Unified commanded attacks and attack-march combat around Battle.net Edition's native attack program while preserving the march destination.
-- Repaired the stalled orc grunt versus ballista encounter captured in the Human 6 save: the first hit now lands after 13 cycles and repeats on the retail 25-cycle cadence.
-- Added authenticated Human 6 coverage that uses the original mission data and prevents this combat deadlock from returning.
-- Preserved all 52 campaign parity results with zero regressions and retained the accepted common frontier at cycle 41.
+- Fixed ballistae and other ranged units leaving phantom projectiles behind when they move, stop, retarget, die, or resume from an older save.
+- Kept pre-launch fireballs, cannonballs, arrows, and axes invisible until Battle.net Edition's authoritative firing moment, eliminating missiles that appeared stuck on their owner before launch.
+- Prevented duplicate presentation callbacks and legacy save data from manufacturing multiple live shots for one attack.
+- Removed abandoned ship cannonballs when their target dies instead of leaving a projectile stranded in the water or reviving it during a later attack.
+- Fixed battleships acknowledging an attack on a coastal building but remaining idle when the final shoreline route step was permanently blocked.
+- Added an in-range water approach for capital ships attacking coastal buildings when no reachable one-tile target skirt exists.
+- Added exact-save regression coverage for the Human 6 ballista and Human expansion 6 battleship reports, plus expanded projectile and movement lifecycle gates.

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
@@ -4904,7 +4904,8 @@ final class GameScreen extends JPanel {
                     missile -> missile.type().drawLevel()));
         }
         for (var missile : flying) {
-            if (missile != withheld.missile()) {
+            if (missile != withheld.missile()
+                    && world.missileVisible(missile)) {
                 drawMissile(g2, missile);
             }
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,6 @@ What is **unverified** rather than done: multiplayer between two physically
 separate machines. It runs between processes on one machine and the lockstep and
 sync-hash machinery is tested, but nobody has recorded a two-machine game.
 
-The test suite is **2,177 tests**. On a fully configured machine 17 skip; with
-no external inputs 709 do. Both numbers matter and the difference between them is the
+The test suite is **2,184 tests**. On a fully configured machine 17 skip; with
+no external inputs 714 do. Both numbers matter and the difference between them is the
 subject of [ci.md](ci.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -16,7 +16,7 @@ green Maven run meant anything.
 **This suite does not fail when its inputs are missing.** Tests that need the
 1995 Warcraft II data, an asset pack or the Opus vectors call
 `Assumptions.assumeTrue(...)` and skip, and Maven reports `BUILD SUCCESS`
-either way. With nothing configured, 709 of 2,177 tests skip and
+either way. With nothing configured, 714 of 2,184 tests skip and
 the run takes 25 seconds.
 
 So the exit code certifies almost nothing on its own, and a CI job that trusts
@@ -57,7 +57,7 @@ anything subtler.
 
 ### Authenticated data -- private self-hosted inputs
 
-Asserts the `full` profile: **17 skips of 2,177**, re-measured after the native
+Asserts the `full` profile: **17 skips of 2,184**, re-measured after the native
 runtime and multiplayer-service additions
 against a real 1995 installation. One of the seventeen depends on which release
 the installation is -- a Battle.net Edition sees 16, which is correct and not a
@@ -83,12 +83,12 @@ Per module and in total:
 The asymmetry is deliberate. Adding a test that always runs raises the run count
 and needs no change here. Adding a test that skips without game data raises the
 skip count and turns CI red until somebody writes the new number down. That
-second case is the one worth catching: it is how 709 tests came to be skippable
+second case is the one worth catching: it is how 714 tests came to be skippable
 in the first place, one at a time, with nothing objecting.
 
 | Profile | Inputs | Skips |
 |---|---|---|
-| `data-free` | none | 709 |
+| `data-free` | none | 714 |
 | `full` | installation, pack, Opus vectors | 17 |
 
 The seventeen that skip even in `full` want nothing anyone should have to

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetCombatSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetCombatSystem.java
@@ -1513,8 +1513,7 @@ final class BattleNetCombatSystem {
                 // that authoritative boundary, not at the early visual
                 // frame -- unless presentation is already mid-wait past
                 // the OP10 tick (same rule as melee below).
-                world.battleNetPendingProjectileShots.put(attacker, shot);
-                world.battleNetPendingProjectileQueuedCycle.put(shot, (long) world.cycle);
+                world.projectiles.queuePendingAttack(attacker, shot, world.cycle);
                 world.logBattleNetPend("pend-put", attacker, target, shot,
                         "presentation-hit", -1);
                 // Mobile weapons: presentation can sit mid-wait before
@@ -2291,6 +2290,7 @@ final class BattleNetCombatSystem {
             unit.rememberActionBeforeQueued(unit.order());
             return true;
         }
+        world.projectiles.interruptPendingAttack(unit);
         world.construction.abandonPendingBuild(unit);
         // offeredTarget is COrder_Attack state upstream. A fresh position
         // order starts without the candidate offered to the order it

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetMovementSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetMovementSystem.java
@@ -136,6 +136,11 @@ final class BattleNetMovementSystem {
         // Two hundred units ordered onto one square are two hundred accepted
         // orders upstream and were a hundred and seventy-nine here.
         world.construction.abandonPendingBuild(unit);
+        // The presentation animation may have allocated a weapon sprite
+        // before retail attack opcode ten. A move replaces that attack order,
+        // so the pre-retail placeholder must go with it instead of remaining
+        // at the old muzzle and waking up beside a later shot.
+        world.projectiles.interruptPendingAttack(unit);
         // Retail tankers select the absolute even-anchor route. A legacy save
         // can contain a 2x2 tanker on an odd anchor, where a doubled step can
         // never repair parity and crosses an odd order point forever. Keep
@@ -1988,7 +1993,21 @@ final class BattleNetMovementSystem {
                 // cell freed (fixture 51) -- two cycles early and without
                 // the full fifteen-count.
                 if (unit.battleNetDoubleStep()) {
-                    if (unit.stepDrained() && !unit.isMoving()
+                    // That hold belongs only to a live body which may vacate
+                    // the anchor. A route can also end with a heading onto
+                    // permanent coast or a building after its bounded prefix
+                    // has carried a capital ship across the map. Treating
+                    // that terrain refusal like the submarine witness above
+                    // preserves the impossible heading forever: every wake
+                    // retries it, rearms fifteen, and an acknowledged attack
+                    // order appears to have been ignored. Drop permanent
+                    // refusals so the still-live move/attack order asks the
+                    // pathfinder for the next route leg around the coast.
+                    Unit blocker = world.blockerOnLayer(unit, nextX, nextY);
+                    boolean temporaryBody = blocker != null
+                            && blocker != unit
+                            && !blocker.type().building();
+                    if (temporaryBody && unit.stepDrained() && !unit.isMoving()
                             && unit.pathLength() > 0) {
                         unit.setBattleNetOrderDelay(14);
                         unit.setWaitCycles(0);

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetProjectileSystem.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/BattleNetProjectileSystem.java
@@ -49,13 +49,87 @@ final class BattleNetProjectileSystem {
         if (pending.battleNetConstructorDrawn()) {
             prepareBattleNetProjectile(pending, attacker.canMove());
         } else {
-            world.missiles.remove(pending);
-            world.battleNetProjectileStartCycles.remove(pending);
-            world.freeBattleNetProjectileSlot(pending.battleNetPoolSlot());
-            pending.setBattleNetPoolSlot(-1);
+            discardPresentationPlaceholder(pending);
         }
         world.battleNetPendingProjectileQueuedCycle.remove(pending);
         world.missileSnapshot = List.copyOf(world.missiles);
+    }
+
+    /**
+     * Installs the sole presentation-ahead shot owned by an attack order.
+     *
+     * <p>Retail has no projectile before attack opcode ten. ChonkCraft creates
+     * one early solely so its independent presentation animation has
+     * something to draw. Replacing the owner-map entry without removing its
+     * old value turns that old sprite into an ordinary global missile: it
+     * remains at the abandoned muzzle until a later missile pass makes it
+     * fly. This is the only insertion path and also repairs duplicate records
+     * restored from saves written while that bug existed.</p>
+     */
+    void queuePendingAttack(Unit attacker, Missile shot, long queuedCycle) {
+        if (attacker == null || shot == null) {
+            return;
+        }
+        Missile previous = world.battleNetPendingProjectileShots.get(attacker);
+        if (previous != null && previous != shot) {
+            // A second presentation callback for the same swing is not a
+            // second retail shot. Keep the order's original placeholder and
+            // erase the just-allocated duplicate. This is especially
+            // important after an early constructor debit: arming the first
+            // and retaining the second would manufacture two live missiles.
+            discardPresentationPlaceholder(shot);
+            world.battleNetPendingProjectileQueuedCycle.remove(shot);
+            world.missileSnapshot = List.copyOf(world.missiles);
+            return;
+        }
+
+        // A broken save records an overwritten placeholder as pending=false,
+        // because only the newer value remains in the owner map. It is still
+        // recognizable: same source, no constructor, no motion and no start.
+        for (Missile candidate : new ArrayList<>(world.missiles)) {
+            if (candidate == shot || candidate.source() != attacker
+                    || candidate.battleNetConstructorDrawn()
+                    || candidate.battleNetMotion()
+                    || world.battleNetProjectileStartCycles.containsKey(candidate)
+                    || !world.battleNetPendingProjectileQueuedCycle.containsKey(candidate)) {
+                continue;
+            }
+            discardPresentationPlaceholder(candidate);
+            world.battleNetPendingProjectileQueuedCycle.remove(candidate);
+        }
+
+        world.battleNetPendingProjectileShots.put(attacker, shot);
+        if (queuedCycle >= 0) {
+            world.battleNetPendingProjectileQueuedCycle.put(shot, queuedCycle);
+        }
+        world.missileSnapshot = List.copyOf(world.missiles);
+    }
+
+    /** Removes an object that never crossed BNE's projectile constructor. */
+    private void discardPresentationPlaceholder(Missile pending) {
+        world.missiles.remove(pending);
+        world.battleNetProjectileStartCycles.remove(pending);
+        world.battleNetProjectileCausalOrdinals.remove(pending);
+        world.freeBattleNetProjectileSlot(pending.battleNetPoolSlot());
+        pending.setBattleNetPoolSlot(-1);
+    }
+
+    /** Cancels placeholders whose owning attack order was replaced directly. */
+    void discardInterruptedPlaceholders() {
+        for (Unit attacker : new ArrayList<>(world.battleNetPendingProjectileShots.keySet())) {
+            Missile pending = world.battleNetPendingProjectileShots.get(attacker);
+            Unit.Order order = attacker.order();
+            boolean ownsAttack = order == Unit.Order.ATTACK
+                    || order == Unit.Order.ATTACK_MOVE
+                    || order == Unit.Order.STAND_GROUND
+                    || order == Unit.Order.ATTACK_GROUND
+                    || (order == Unit.Order.STILL && !attacker.canMove());
+            boolean ownsTarget = pending == null || pending.target() == null
+                    || pending.target() == attacker.target();
+            if (!attacker.isAlive() || !ownsAttack || !ownsTarget) {
+                interruptPendingAttack(attacker);
+            }
+        }
     }
 
 
@@ -416,6 +490,7 @@ final class BattleNetProjectileSystem {
      * fault that only shows up once an explosion has an explosion.
      */
     void stepMissiles() {
+        discardInterruptedPlaceholders();
         if (world.missiles.isEmpty()) {
             return;
         }

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/World.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/World.java
@@ -3492,6 +3492,7 @@ public final class World {
             unit.rememberActionBeforeQueued(unit.order());
             return true;
         }
+        projectiles.interruptPendingAttack(unit);
         construction.abandonPendingBuild(unit);
         unit.setPendingAttack(null, null, -1, -1);
         unit.setTarget(target);
@@ -5089,6 +5090,46 @@ public final class World {
                             && y >= targetTop - 1
                             && y <= targetBottom + 1,
                     true);
+            // A coastal building can have no reachable one-square target
+            // skirt for a doubled naval anchor even though the weapon can
+            // fire from open water. COrder_Attack::UpdatePathFinderData gives
+            // retail's path input the weapon's min/max range as well as the
+            // target footprint. Preserve the tightly captured one-square
+            // marker when it produces a route; when it cannot produce even
+            // one heading, retry with reachable in-range water anchors. This
+            // is the missing half of that input and prevents a battleship
+            // from acknowledging an attack, reaching the coast, then
+            // replanning an empty route forever until the player manually
+            // moves it closer.
+            if (path.length() == 0
+                    && path.result() == PathFinder.Result.FOUND
+                    && unit.battleNetDoubleStep()
+                    && unit.type().seaUnit()
+                    && target.type().building()
+                    && !targets.inAttackRange(unit, target)) {
+                int minRange = Math.max(0, unit.type().minAttackRange());
+                int maxRange = Math.max(1, unit.type().maxAttackRange());
+                PathFinder.Path ranged = BattleNetPathFinder.find(
+                        unit.tileX(), unit.tileY(), goalX, goalY,
+                        battleNetMovementStride(unit), traversalPassability,
+                        optimizationPassability,
+                        (x, y) -> {
+                            if (!traversalPassability.canEnter(x, y)) {
+                                return false;
+                            }
+                            int nearX = battleNetNearFootprintCoordinate(
+                                    x, targetLeft, targetWidth);
+                            int nearY = battleNetNearFootprintCoordinate(
+                                    y, targetTop, targetHeight);
+                            int distance = Math.max(Math.abs(nearX - x),
+                                    Math.abs(nearY - y));
+                            return distance >= minRange && distance <= maxRange;
+                        },
+                        true);
+                if (ranged.length() > 0) {
+                    path = ranged;
+                }
+            }
             traceBattleNetPath(unit, goalX, goalY, path);
             return path;
         } finally {
@@ -7571,6 +7612,7 @@ public final class World {
             construction.cancelConstruction(unit);
             return;
         }
+        projectiles.interruptPendingAttack(unit);
         unit.setPendingHarvest(-1, -1);
         unit.clearQueuedOrders();
         unit.setSavedOrder(null);
@@ -8053,6 +8095,11 @@ public final class World {
             }
             releaseUnreferencedDestroyedUnits();
         }
+        // Player and AI commands may replace an attack between its early
+        // presentation frame and BNE opcode ten. Cancel that order-owned
+        // placeholder before cycle-end constructor debits can turn it into a
+        // real shot. stepMissiles repeats the check for direct/test callers.
+        projectiles.discardInterruptedPlaceholders();
         projectiles.flushBattleNetCycleEndConstructorDebit();
         projectiles.stepMissiles();
         regenerateMana();
@@ -8971,6 +9018,21 @@ public final class World {
         return battleNetPendingProjectileShots.containsValue(missile);
     }
 
+    /**
+     * Whether a missile has crossed the retail constructor boundary and may
+     * be drawn.
+     *
+     * <p>Mobile attack presentation can allocate a bookkeeping placeholder
+     * before BNE reaches opcode ten. It belongs to no retail frame yet. The
+     * renderer used to draw that placeholder at the muzzle, leaving a
+     * fireball apparently stuck on a battleship for several seconds before
+     * the real launch. Keep the object private to simulation until its owner
+     * reaches the authoritative firing opcode.</p>
+     */
+    public boolean missileVisible(Missile missile) {
+        return missile != null && !savedProjectilePending(missile);
+    }
+
     /** Resolves a saved missile type and restores it without a launch sound. */
     public void restoreMissile(String typeIdent, Unit source, Unit target,
             Missile.SavedState state, long startCycle, long queuedCycle,
@@ -8992,7 +9054,7 @@ public final class World {
                 battleNetPendingProjectileQueuedCycle.put(missile, queuedCycle);
             }
             if (pending && source != null) {
-                battleNetPendingProjectileShots.put(source, missile);
+                projectiles.queuePendingAttack(source, missile, queuedCycle);
             }
         }
     }
@@ -11628,6 +11690,7 @@ public final class World {
         if ((missile == null || missile.isNone()) && !map.field(toX, toY).isWall()) {
             return false;
         }
+        projectiles.interruptPendingAttack(unit);
         unit.clearPath();
         unit.setOrderTarget(toX, toY);
         unit.setSavedOrder(null);
@@ -12514,6 +12577,7 @@ public final class World {
         if (unit == null || !unit.isAlive()) {
             return;
         }
+        projectiles.interruptPendingAttack(unit);
         unit.clearPath();
         unit.setTarget(null);
         unit.setFighting(false);

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/BattleshipCoastalAttackTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/BattleshipCoastalAttackTest.java
@@ -1,0 +1,111 @@
+package net.chonkbase.chonkcraft.engine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.chonkbase.chonkcraft.engine.animation.Animation;
+import net.chonkbase.chonkcraft.engine.animation.AnimationSet;
+import net.chonkbase.chonkcraft.engine.map.Direction;
+import net.chonkbase.chonkcraft.engine.map.GameMap;
+import net.chonkbase.chonkcraft.engine.map.TileFlag;
+import net.chonkbase.chonkcraft.engine.map.Tileset;
+import net.chonkbase.chonkcraft.engine.pathfinder.PathFinder;
+import net.chonkbase.chonkcraft.engine.unit.Unit;
+import net.chonkbase.chonkcraft.engine.unit.UnitType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Regression coverage for large warships chasing coastal buildings. */
+class BattleshipCoastalAttackTest {
+
+    private static UnitType combatant(String ident) {
+        UnitType type = new UnitType(ident);
+        type.setName(ident);
+        type.setTileSize(1, 1);
+        type.setHitPoints(500);
+        type.setSpeed(32);
+        type.setCanAttack(true);
+        type.setCanTargetLand(true);
+        type.setBasicDamage(20);
+        type.setMaxAttackRange(1);
+        type.setSightRange(16);
+        type.setMissile("missile-none");
+        AnimationSet set = new AnimationSet(ident);
+        set.put(AnimationSet.State.STILL,
+                Animation.parse("still", List.of("frame 0", "wait 1")));
+        set.put(AnimationSet.State.MOVE,
+                Animation.parse("move", List.of(
+                        "unbreakable begin", "frame 0", "move 32",
+                        "unbreakable end", "wait 1")));
+        set.put(AnimationSet.State.ATTACK,
+                Animation.parse("attack", List.of(
+                        "unbreakable begin", "frame 0", "attack",
+                        "unbreakable end", "wait 1")));
+        type.setAnimationSet(set);
+        return type;
+    }
+
+    private static UnitType battleship() {
+        UnitType type = combatant("unit-battleship");
+        type.setSeaUnit(true);
+        type.setTileSize(2, 2);
+        type.setMaxAttackRange(6);
+        return type;
+    }
+
+    private static UnitType shipyard() {
+        UnitType type = combatant("unit-orc-shipyard");
+        type.setBuilding(true);
+        type.setTileSize(3, 3);
+        type.setSpeed(0);
+        type.setCanAttack(false);
+        return type;
+    }
+
+    private static GameMap openWater(int size) {
+        GameMap map = new GameMap(size, size, new Tileset());
+        for (int y = 0; y < size; y++) {
+            for (int x = 0; x < size; x++) {
+                map.field(x, y).setFlags(TileFlag.WATER_ALLOWED);
+            }
+        }
+        return map;
+    }
+
+    @Test
+    @DisplayName("a capital ship drops a coast-blocked cached step and replans")
+    void capitalShipReplansAStaleTerrainBlockedChaseStep() {
+        GameMap map = openWater(40);
+        // The stale route's west anchor is permanent coast, while north-west
+        // is open water and a fresh route can carry the ship around it.
+        map.field(18, 20).setFlags(TileFlag.LAND_ALLOWED);
+        World world = new World(map);
+        world.setAllied(0, 1, false);
+        Unit ship = world.createUnit(battleship(), 0, 20, 20);
+        Unit port = world.createUnit(shipyard(), 1, 6, 12);
+
+        assertTrue(world.orderAttack(ship, port));
+        ship.setChasing(true);
+        ship.setStepDrained(true);
+        ship.setPathGoal(port.tileX(), port.tileY());
+        ship.setPath(new PathFinder.Path(PathFinder.Result.FOUND,
+                new int[] {Direction.fromDelta(-1, 0)}));
+
+        world.tick();
+
+        assertEquals(0, ship.pathLength(),
+                "permanent coast was preserved like a temporary ship blocker");
+        assertEquals(0, ship.battleNetOrderDelay(),
+                "permanent coast incorrectly armed the congestion hold");
+        boolean moved = false;
+        for (int cycle = 0; cycle < 80 && !moved; cycle++) {
+            world.tick();
+            moved = ship.tileX() != 20 || ship.tileY() != 20;
+        }
+        assertTrue(moved, "the live attack order never replanned around the coast");
+        assertSame(port, ship.target(), "replanning discarded the requested shipyard");
+    }
+
+}

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/PresentationAheadProjectilePrepareTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/PresentationAheadProjectilePrepareTest.java
@@ -587,6 +587,123 @@ class PresentationAheadProjectilePrepareTest {
     }
 
     @Test
+    @DisplayName("moving a siege unit cancels its pre-opcode projectile")
+    void moveOrderCancelsPresentationShotAtTheOldMuzzle() throws IOException {
+        World world = new World(grass(32));
+        world.fog().revealAll(0);
+        world.fog().revealAll(1);
+        world.setAllied(0, 1, false);
+        world.setMissileTypes(Map.of("missile-axe", axeMissile()));
+        world.setBattleNetSequenceData(retailScriptBin());
+
+        Unit shooter = world.createUnit(axethrower(), 0, 8, 10);
+        Unit target = world.createUnit(grunt(), 1, 12, 10);
+        assertTrue(world.orderAttack(shooter, target));
+        world.hit(shooter, target);
+
+        assertEquals(1, world.missiles().size(), "one pre-opcode placeholder");
+        Missile oldMuzzle = world.missiles().get(0);
+        int oldSlot = oldMuzzle.battleNetPoolSlot();
+        assertFalse(oldMuzzle.battleNetConstructorDrawn());
+
+        assertTrue(world.orderMove(shooter, 8, 14), "move order accepted");
+
+        assertFalse(world.missiles().contains(oldMuzzle),
+                "the projectile sprite remained at the siege unit's old position");
+        assertTrue(world.battleNetPendingProjectileShots.isEmpty(),
+                "the replaced attack order still owned a projectile");
+        assertFalse(world.battleNetProjectileSlots[oldSlot],
+                "the cancelled placeholder leaked its projectile-pool slot");
+    }
+
+    @Test
+    @DisplayName("one attacker can own only one pre-opcode projectile")
+    void repeatedPresentationHitReplacesRatherThanOrphansThePlaceholder()
+            throws IOException {
+        World world = new World(grass(32));
+        world.fog().revealAll(0);
+        world.fog().revealAll(1);
+        world.setAllied(0, 1, false);
+        world.setMissileTypes(Map.of("missile-axe", axeMissile()));
+        world.setBattleNetSequenceData(retailScriptBin());
+
+        Unit shooter = world.createUnit(axethrower(), 0, 8, 10);
+        Unit target = world.createUnit(grunt(), 1, 12, 10);
+        assertTrue(world.orderAttack(shooter, target));
+        world.hit(shooter, target);
+        Missile first = world.missiles().get(0);
+
+        world.hit(shooter, target);
+
+        assertEquals(1, world.missiles().size(),
+                "overwriting the owner map left an unowned phantom missile");
+        assertTrue(world.missiles().contains(first),
+                "a duplicate callback replaced the attack order's original shot");
+        assertEquals(first,
+                world.battleNetPendingProjectileShots.get(shooter));
+    }
+
+    @Test
+    @DisplayName("retargeting cancels the previous target's pre-opcode shot")
+    void attackRetargetCannotCarryTheOldTargetsPlaceholder() throws IOException {
+        World world = new World(grass(32));
+        world.fog().revealAll(0);
+        world.fog().revealAll(1);
+        world.setAllied(0, 1, false);
+        world.setMissileTypes(Map.of("missile-axe", axeMissile()));
+        world.setBattleNetSequenceData(retailScriptBin());
+
+        Unit shooter = world.createUnit(axethrower(), 0, 8, 10);
+        Unit firstTarget = world.createUnit(grunt(), 1, 12, 10);
+        Unit secondTarget = world.createUnit(grunt(), 1, 12, 12);
+        assertTrue(world.orderAttack(shooter, firstTarget));
+        world.hit(shooter, firstTarget);
+        Missile oldShot = world.missiles().get(0);
+
+        assertTrue(world.orderAttack(shooter, secondTarget));
+
+        assertFalse(world.missiles().contains(oldShot),
+                "the new attack inherited the previous target's projectile");
+        assertTrue(world.battleNetPendingProjectileShots.isEmpty());
+    }
+
+    @Test
+    @DisplayName("loading a broken duplicate projectile save heals its owner list")
+    void duplicateLegacySavePlaceholdersCollapseToOne() {
+        World world = new World(grass(32));
+        MissileType axe = axeMissile();
+        world.setMissileTypes(Map.of("missile-axe", axe));
+        Unit shooter = world.createUnit(axethrower(), 0, 8, 10);
+        Unit target = world.createUnit(grunt(), 1, 12, 10);
+        shooter.setOrder(Unit.Order.ATTACK);
+        shooter.setTarget(target);
+
+        Missile overwritten = new Missile(axe, shooter, target,
+                272, 336, 400, 336);
+        overwritten.setBattleNetPoolSlot(3);
+        Missile owned = new Missile(axe, shooter, target,
+                304, 336, 400, 336);
+        owned.setBattleNetPoolSlot(4);
+
+        // This is the schema produced by the bug: the older shot was still
+        // serialized but no longer marked pending after the owner map was
+        // overwritten by the newer one.
+        world.restoreMissile("missile-axe", shooter, target,
+                overwritten.savedState(), -1, 20, false);
+        world.restoreMissile("missile-axe", shooter, target,
+                owned.savedState(), -1, 21, true);
+
+        assertEquals(1, world.missiles().size(),
+                "load retained both the orphan and the owned placeholder");
+        assertEquals(owned.savedState(), world.missiles().get(0).savedState(),
+                "load discarded the attack order's newest placeholder");
+        assertEquals(world.missiles().get(0),
+                world.battleNetPendingProjectileShots.get(shooter));
+        assertFalse(world.battleNetProjectileSlots[3],
+                "healing the old save leaked the orphan's pool slot");
+    }
+
+    @Test
     @DisplayName("a destroyer's unconstructed final shell vanishes when its target dies")
     void targetDeathCancelsTheShipsOrphanedPendingCannonball() throws IOException {
         GameMap map = grass(24);

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/save/SaveGameTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/save/SaveGameTest.java
@@ -38,6 +38,108 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class SaveGameTest {
 
+    @Test
+    @DisplayName("the Human expansion 6 battleships can reach every saved shipyard")
+    void humanExpansionSixBattleshipsReachEverySavedShipyard() throws IOException {
+        AssetSource assets = AssetSource.fromEnvironment();
+        Assumptions.assumeTrue(assets != null,
+                "No asset pack/install configured. Set -Dchonkcraft.pack or wc2.install.dir.");
+        Path save = Path.of(System.getProperty("user.home"), ".chonkcraft", "saves",
+                "human-exp-mission-6.sav.gz");
+        Assumptions.assumeTrue(Files.isRegularFile(save),
+                "the Human expansion 6 playtest save is not installed");
+
+        GameData data = new GameData(assets);
+        String script = LoadGame.read(save);
+        LoadGame.Header header = LoadGame.header(script);
+        assertNotNull(header);
+        for (int attackerId : new int[] {191, 195}) {
+            for (int targetId : new int[] {217, 239, 251}) {
+                var mission = data.loadMission(header.mapPath());
+                assertNotNull(mission);
+                for (Unit unit : new ArrayList<>(mission.world().units())) {
+                    mission.world().remove(unit);
+                }
+                LoadGame.apply(mission.world(), script, data.unitTypes().types());
+                World world = mission.world();
+                Unit attacker = world.units().stream()
+                        .filter(unit -> unit.id() == attackerId)
+                        .findFirst().orElse(null);
+                Unit target = world.units().stream()
+                        .filter(unit -> unit.id() == targetId)
+                        .findFirst().orElse(null);
+                assertNotNull(attacker, "saved battleship " + attackerId + " is missing");
+                assertNotNull(target, "saved shipyard " + targetId + " is missing");
+                world.fog().revealAll(attacker.player());
+                // Keep the route and target geometry from the exact save but
+                // remove defenders so this measures command fulfillment, not
+                // whether the lone battleship survives the whole enemy base.
+                for (Unit unit : new ArrayList<>(world.units())) {
+                    if (unit != attacker && unit != target
+                            && world.isEnemyPlayer(attacker.player(), unit.player())) {
+                        world.remove(unit);
+                    }
+                }
+                int hitPoints = target.hitPoints();
+                assertTrue(world.orderAttack(attacker, target),
+                        "saved battleship refused shipyard " + targetId);
+                for (int cycle = 0; cycle < 3_000
+                        && target.hitPoints() == hitPoints; cycle++) {
+                    world.tick();
+                }
+                assertTrue(target.hitPoints() < hitPoints,
+                        "battleship " + attackerId + " never reached shipyard "
+                                + targetId + " without a manual move order");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("the Human 6 playtest save drops its pending ballista bolt on move")
+    void humanSixPendingBallistaBoltIsCancelledByMove() throws IOException {
+        AssetSource assets = AssetSource.fromEnvironment();
+        Assumptions.assumeTrue(assets != null,
+                "No asset pack/install configured. Set -Dchonkcraft.pack or wc2.install.dir.");
+        Path save = Path.of(System.getProperty("user.home"), ".chonkcraft", "saves",
+                "human-mission-6.sav.gz");
+        Assumptions.assumeTrue(Files.isRegularFile(save),
+                "the Human 6 playtest save is not installed");
+
+        GameData data = new GameData(assets);
+        String script = LoadGame.read(save);
+        LoadGame.Header header = LoadGame.header(script);
+        assertNotNull(header);
+        var mission = data.loadMission(header.mapPath());
+        assertNotNull(mission);
+        for (Unit unit : new ArrayList<>(mission.world().units())) {
+            mission.world().remove(unit);
+        }
+        LoadGame.apply(mission.world(), script, data.unitTypes().types());
+
+        Unit ballista = mission.world().units().stream()
+                .filter(unit -> unit.type() != null
+                        && "unit-ballista".equals(unit.type().ident())
+                        && unit.tileX() == 41 && unit.tileY() == 61)
+                .findFirst().orElse(null);
+        assertNotNull(ballista, "saved ballista 18 at 41,61 is missing");
+        assertEquals("unit-ballista", ballista.type().ident());
+        assertEquals(1, mission.world().missiles().size(),
+                "the save must restore its one pending ballista bolt");
+        Missile oldMuzzle = mission.world().missiles().get(0);
+        assertTrue(mission.world().savedProjectilePending(oldMuzzle));
+
+        assertTrue(mission.world().orderMove(ballista,
+                ballista.tileX() + 2, ballista.tileY()), "ballista move refused");
+
+        assertTrue(mission.world().missiles().isEmpty(),
+                "the exact save retained its old-muzzle bolt after moving");
+        for (int cycle = 0; cycle < 20; cycle++) {
+            mission.world().tick();
+        }
+        assertTrue(mission.world().missiles().isEmpty(),
+                "the cancelled saved bolt woke up and fired later");
+    }
+
     private record Fixture(GameData data, World world, PudMap source, String mapPath) {}
 
     private static Fixture load() {

--- a/scripts/check-bne-movement-gate.sh
+++ b/scripts/check-bne-movement-gate.sh
@@ -12,7 +12,7 @@ if [[ ! -f "${asset_pack}" ]]; then
 fi
 
 CHONKCRAFT_ASSET_PACK="${asset_pack}" "${repo_root}/scripts/run-tests.sh" -pl engine -am \
-  '-Dtest=BattleNetMovementPlayabilityTest,BattleNetPathFinderTest,BattleNetWallFollowBoundsTest,BattleNetNavalLegalityRealDataTest,TransportUnloadTest,ShoreBuildingTest,NavalPatrolCoastGoalRealDataTest,NavalAirTest,RefusedStepTest,BattleNetRefusalSleepTest,BattleNetChaseRefusalTest,BattleNetSeaOccupancyTest,PathAroundUnitsTest' \
+  '-Dtest=BattleNetMovementPlayabilityTest,BattleNetPathFinderTest,BattleNetWallFollowBoundsTest,BattleNetNavalLegalityRealDataTest,TransportUnloadTest,ShoreBuildingTest,NavalPatrolCoastGoalRealDataTest,NavalAirTest,RefusedStepTest,BattleNetRefusalSleepTest,BattleNetChaseRefusalTest,BattleNetSeaOccupancyTest,BattleshipCoastalAttackTest,PathAroundUnitsTest' \
   -Dsurefire.failIfNoSpecifiedTests=false
 
 python3 - "${repo_root}/engine/target/surefire-reports" <<'PY'
@@ -26,7 +26,8 @@ names = {
     "BattleNetWallFollowBoundsTest", "BattleNetNavalLegalityRealDataTest",
     "TransportUnloadTest", "ShoreBuildingTest", "NavalPatrolCoastGoalRealDataTest",
     "NavalAirTest", "RefusedStepTest", "BattleNetRefusalSleepTest",
-    "BattleNetChaseRefusalTest", "BattleNetSeaOccupancyTest", "PathAroundUnitsTest",
+    "BattleNetChaseRefusalTest", "BattleNetSeaOccupancyTest",
+    "BattleshipCoastalAttackTest", "PathAroundUnitsTest",
 }
 tests = skipped = failures = errors = 0
 seen = set()
@@ -41,12 +42,12 @@ for report in root.glob("TEST-*.xml"):
     failures += int(suite.attrib.get("failures", 0))
     errors += int(suite.attrib.get("errors", 0))
 missing = names - seen
-if missing or tests != 88 or skipped or failures or errors:
+if missing or tests != 90 or skipped or failures or errors:
     raise SystemExit(
-        f"movement referee: expected 88/0/0/0 with every class present; "
+        f"movement referee: expected 90/0/0/0 with every class present; "
         f"got {tests}/{skipped}/{failures}/{errors}, missing={sorted(missing)}"
     )
-print("movement edge referee: 88 pass, 0 skipped")
+print("movement edge referee: 90 pass, 0 skipped")
 PY
 
 echo "movement gate passed: large footprints, congestion and refusal recovery"

--- a/scripts/check-bne-projectile-gate.sh
+++ b/scripts/check-bne-projectile-gate.sh
@@ -30,7 +30,7 @@ expected = {
     "ImpactRenderingTest": 2,
     "NativeMissileRealDataTest": 1,
     "ClickMarkerTest": 3,
-    "PresentationAheadProjectilePrepareTest": 8,
+    "PresentationAheadProjectilePrepareTest": 13,
     "RareSpellBehaviorTest": 8,
 }
 observed = {}
@@ -45,7 +45,7 @@ for name, count in expected.items():
     actual = observed.get(name)
     if actual != (count, 0, 0, 0):
         raise SystemExit(f"{name}: expected {(count, 0, 0, 0)}, got {actual}")
-print("projectile lifecycle referee: 54 pass, 0 skipped")
+print("projectile lifecycle referee: 59 pass, 0 skipped")
 PY
 
 echo "projectile gate passed: flight, impact, persistent effects and click feedback"

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -5,7 +5,7 @@
 #
 # It exists because the suite skips rather than fails when its external inputs
 # are missing, so an unconfigured machine gets BUILD SUCCESS out of a run that
-# verified almost nothing. 709 of 2177 tests skip that way. This prints the
+# verified almost nothing. 714 of 2184 tests skip that way. This prints the
 # difference before you spend twenty-five seconds wondering why the run was
 # fast.
 #
@@ -208,7 +208,7 @@ head2 "What a test run would exercise"
 
 if [[ "$wc2_ok" == 1 && "$pack_ok" == 1 && "$opus_ok" == 1 ]]; then
     printf '  All three external inputs are configured.\n'
-    printf '  Expect 2177 tests, 17 skipped, and about four minutes of wall time.\n'
+    printf '  Expect 2184 tests, 17 skipped, and about four minutes of wall time.\n'
     printf '  Seven of the 17 need a display; five need a music fixture nobody is\n'
     printf '  asked to have (-Dopus.music); four are fixture-sensitive skips in\n'
     printf '  FacingCount, AutoAttack, AutoCastToggle and CommandSinkGuard. The\n'
@@ -228,7 +228,7 @@ elif [[ "$wc2_ok" == 1 ]]; then
 else
     printf '  At least one external input is missing.\n'
     printf '  The suite will still report BUILD SUCCESS, having skipped most of itself:\n'
-    printf '  with no input at all, 709 of 2177 tests skip and the run takes 25 seconds.\n'
+    printf '  with no input at all, 714 of 2184 tests skip and the run takes 25 seconds.\n'
     printf '  That is not a passing run. See docs/development-setup.md.\n'
 fi
 

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,8 +9,8 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. Measured on one commit, on one
 machine, the difference is:
 
-    authenticated inputs       2177 tests,  17 skipped
-    no external input          2177 tests, 709 skipped
+    authenticated inputs       2184 tests,  17 skipped
+    no external input          2184 tests, 714 skipped
 
 Both can be green.
 
@@ -133,9 +133,11 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # ShoreBuildingTest's accepted-order referee and the authenticated
         # attack-program lifecycle referees deliberately need the retail data
         # or derived pack they drive. They skip here and run in the full
-        # profile. The August 12 convergence work added ten engine tests;
-        # six are authenticated-data referees and four are hermetic.
-        "engine": (1343, 425),
+        # profile. The siege/naval-fire batch added seven engine tests: the
+        # two exact-save referees and three retail-program projectile tests
+        # skip here, while the duplicate-save and coast-replan tests are
+        # hermetic.
+        "engine": (1350, 430),
         "desktop": (287, 231),
         "matchmaker-server": (4, 0),
     },
@@ -176,7 +178,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (46, 0),
         "matchmaking": (2, 0),
-        "engine": (1343, 2),
+        "engine": (1350, 2),
         "desktop": (287, 6),
         "matchmaker-server": (4, 0),
     },


### PR DESCRIPTION
## What changed

- make pre-launch projectiles private until the authoritative BNE firing event
- cancel pending shots when attacks are replaced, interrupted, or restored from broken legacy saves
- recover capital-ship attacks from permanent shoreline refusals and route to reachable in-range water
- add exact-save and subsystem regression coverage

## Root cause

Presentation placeholders could outlive their owning attack order and become visible or fire later. Separately, doubled naval routes treated permanent coast/building refusals as temporary congestion, preserving an impossible heading forever.

## Verification

- projectile lifecycle gate: 59 passed, 0 skipped
- movement edge gate: 90 passed, 0 skipped
- exact Human 6 and Human expansion 6 save regressions passed
- documentation and diff integrity checks passed