### PR TITLE
Record authenticated playtest save skips

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,6 +264,6 @@ What is **unverified** rather than done: multiplayer between two physically
 separate machines. It runs between processes on one machine and the lockstep and
 sync-hash machinery is tested, but nobody has recorded a two-machine game.
 
-The test suite is **2,184 tests**. On a fully configured machine 17 skip; with
+The test suite is **2,184 tests**. On a fully configured CI machine 19 skip; with
 no external inputs 714 do. Both numbers matter and the difference between them is the
 subject of [ci.md](ci.md).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -57,10 +57,10 @@ anything subtler.
 
 ### Authenticated data -- private self-hosted inputs
 
-Asserts the `full` profile: **17 skips of 2,184**, re-measured after the native
+Asserts the `full` profile: **19 skips of 2,184**, re-measured after the siege
 runtime and multiplayer-service additions
-against a real 1995 installation. One of the seventeen depends on which release
-the installation is -- a Battle.net Edition sees 16, which is correct and not a
+against a real 1995 installation. One of the nineteen depends on which release
+the installation is -- a Battle.net Edition sees 18, which is correct and not a
 regression; `scripts/ci/check-test-skips.py` explains it at the profile.
 About nine minutes.
 
@@ -89,12 +89,14 @@ in the first place, one at a time, with nothing objecting.
 | Profile | Inputs | Skips |
 |---|---|---|
 | `data-free` | none | 714 |
-| `full` | installation, pack, Opus vectors | 17 |
+| `full` | installation, pack, Opus vectors | 19 |
 
-The seventeen that skip even in `full` want nothing anyone should have to
+The nineteen that skip even in `full` want nothing anyone should have to
 provide: seven need a display, five need a directory of 16-bit WAVs
 (`-Dopus.music`) that this project does not ask anybody for, and four are
 fixture-sensitive behaviours absent from the pinned installation and scripts.
+Two exact-save referees additionally need the operator's private playtest saves,
+and one video assertion depends on which retail release is mounted.
 
 ## The failure gate
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -485,7 +485,7 @@ re-baseline the counts.
 The hosted, data-free job runs on every push and pull request. A private
 authenticated job runs only for `master` pushes or a maintainer's manual
 dispatch, using a read-only copy of the installation and authenticated pack.
-It asserts 17 skips, so 2,148 tests actually run without exposing licensed
+It asserts 19 skips, so 2,165 tests actually run without exposing licensed
 media to public pull-request code.
 
 ## Packaging

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -208,12 +208,12 @@ head2 "What a test run would exercise"
 
 if [[ "$wc2_ok" == 1 && "$pack_ok" == 1 && "$opus_ok" == 1 ]]; then
     printf '  All three external inputs are configured.\n'
-    printf '  Expect 2184 tests, 17 skipped, and about four minutes of wall time.\n'
-    printf '  Seven of the 17 need a display; five need a music fixture nobody is\n'
+    printf '  Expect 2184 tests, 19 skipped, and about four minutes of wall time.\n'
+    printf '  Seven of the 19 need a display; five need a music fixture nobody is\n'
     printf '  asked to have (-Dopus.music); four are fixture-sensitive skips in\n'
-    printf '  FacingCount, AutoAttack, AutoCastToggle and CommandSinkGuard. The\n'
-    printf '  seventeenth wants a Battle.net installation, so another release\n'
-    printf '  skips it and a Battle.net one shows 16.\n'
+    printf '  FacingCount, AutoAttack, AutoCastToggle and CommandSinkGuard; two\n'
+    printf '  need local playtest saves. The nineteenth is release-sensitive, so\n'
+    printf '  a Battle.net installation runs it and reports 18 skips.\n'
 elif [[ "$wc2_ok" == 1 ]]; then
     printf '  The game data is configured; one or more optional test inputs are not,\n'
     printf '  so more than the minimum number of tests will skip.\n'

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,7 +9,7 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. Measured on one commit, on one
 machine, the difference is:
 
-    authenticated inputs       2184 tests,  17 skipped
+    authenticated inputs       2184 tests,  19 skipped
     no external input          2184 tests, 714 skipped
 
 Both can be green.
@@ -94,8 +94,8 @@ MODULES = (
 # Measured on macOS 27 aarch64, JBR 25.0.2, against chonkcraft at
 # v3.3.2-145-gcde1a071 and a 1995 DOS install of Tides of Darkness.
 #
-# Seventeen skip even in `full`. Sixteen of them want something other than
-# game data; the seventeenth wants a different release of it, and is described
+# Nineteen skip even in `full`. Eighteen of them want something other than
+# game data; the nineteenth wants a different release of it, and is described
 # at the `full` profile below.
 #
 # Seven need a **display**: AppWindowTest's four, and three of
@@ -154,20 +154,21 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
     # Re-measured 7 August 2026 against a real 1995 installation, the first
     # time this profile has been measured since the suite grew past 1,694
     # tests. It had expected 893 engine tests where there are 1,274. The
-    # seventeen that skip are: five CELT encoder tests wanting a music fixture
+    # nineteen that skip are: five CELT encoder tests wanting a music fixture
     # nobody is asked to have (-Dopus.music), seven window and fullscreen
     # tests in runtime and desktop, four fixture-sensitive ones in
     # FacingCountTest, AutoAttackTest, AutoCastToggleTest and
-    # CommandSinkGuardTest, and one release-dependent test described below.
+    # CommandSinkGuardTest, two local playtest-save regression referees, and
+    # one release-dependent test described below.
     #
-    # ONE OF THE SEVENTEEN DEPENDS ON WHICH RELEASE THE INSTALLATION IS, and it
+    # ONE OF THE NINETEEN DEPENDS ON WHICH RELEASE THE INSTALLATION IS, and it
     # is the reason to read this note before believing a red gate.
     # SmackerVideoTest.battleNetStereoAudioUsesTheRightByteOrder asks
     # `videos.source().isBattleNetEdition()` and skips on anything else. This
     # baseline was measured on a Tides of Darkness installation, so it counts
     # that skip and `data` reads (130, 1). On a Battle.net Edition
     # installation -- which is this port's parity oracle -- the test runs
-    # instead, `data` reads (130, 0), and the total is 16. That is a correct
+    # instead, `data` reads (130, 0), and the total is 18. That is a correct
     # run reporting one fewer skip, not a regression. Nothing here can tell
     # the two apart, because the profile is a pair of numbers per module and
     # the release is not an input the profile knows about.
@@ -178,7 +179,10 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (46, 0),
         "matchmaking": (2, 0),
-        "engine": (1350, 2),
+        # Two exact-save regressions need the operator's local Human 6 saves.
+        # They are intentionally additional authenticated playtest coverage,
+        # not artifacts derived from the mounted retail installation.
+        "engine": (1350, 4),
         "desktop": (287, 6),
         "matchmaker-server": (4, 0),
     },


### PR DESCRIPTION
## What changed

- record the two exact-save playtest referees as intentional skips on authenticated CI machines that do not carry private operator saves
- update the full and data-free suite totals and accompanying documentation

## Why

The beta19 fix added seven regression tests. The full suite runs five more than before; the two exact-save tests remain optional because CI correctly does not contain a developer home directory. The strict skip gate caught the undocumented distinction.

## Verification

- measured master full profile: 2,184 tests, 19 skipped
- measured data-free profile: 2,184 tests, 714 skipped
- documentation and diff checks pass