### PR TITLE
Update lockstep release inventory

### DIFF
--- a/scripts/check-bne-network-gate.sh
+++ b/scripts/check-bne-network-gate.sh
@@ -23,12 +23,12 @@ observed = int(suite.attrib.get("tests", -1))
 skipped = int(suite.attrib.get("skipped", -1))
 failures = int(suite.attrib.get("failures", -1))
 errors = int(suite.attrib.get("errors", -1))
-if observed != 34 or skipped or failures or errors:
+if observed != 36 or skipped or failures or errors:
     raise SystemExit(
-        "LockstepTest: expected 34/0/0/0 tests/skips/failures/errors, "
+        "LockstepTest: expected 36/0/0/0 tests/skips/failures/errors, "
         f"got {observed}/{skipped}/{failures}/{errors}"
     )
-print("lockstep inventory: 34 pass, 0 skipped")
+print("lockstep inventory: 36 pass, 0 skipped")
 PY
 
 echo "network gate passed: independent peers converge through 1800 cycles and adverse UDP"


### PR DESCRIPTION
## What changed

Updates the production multiplayer gate's exact `LockstepTest` inventory from 34 to 36 after the two new rejected-command transaction tests landed.

## Why

The authenticated master lane passed all 36 lockstep tests but correctly refused to continue because the release gate still expected the old suite size.

## Validation

- 36/36 lockstep tests pass with zero skips, failures, or errors
- real two-process multiplayer startup passes
- client receives the host map
- both peers render a visible initial view and converge through 180 cycles to hash `9bb26c672d20447d`
