### PR TITLE
Keep menus quick and palette animation within a bounded graphics budget

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Gameplay Reliability Update
 
+- Made menu scaling use reusable graphics surfaces, avoiding full-window
+  temporary images on every redraw. Waiting lobbies now redraw only when
+  their displayed information changes.
+- Fixed palette animation accumulating graphics memory outside the Java heap.
+  Terrain and sprite caches now have memory limits and release device images
+  when leaving a screen. Rendering allocates less memory while preserving
+  palette colours and changes to the ground.
+- Made stone panels reuse their existing texture during window resizing,
+  reduced the game's initial heap reservation, and smoothed the launcher's
+  progress animation while stopping its timer when hidden.
 - Fixed repeated Start clicks or holding Enter in a multiplayer lobby opening
   several copies of the same match while the map loaded. Start now becomes
   unavailable as soon as loading begins.

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/BriefingScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/BriefingScreen.java
@@ -82,7 +82,7 @@ final class BriefingScreen extends JPanel {
 
     /** The briefing drawn at its own size, and the scaler's working copy. */
     private java.awt.image.BufferedImage design;
-    private java.awt.image.BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     /**
      * The wash behind the prose.
@@ -275,6 +275,15 @@ final class BriefingScreen extends JPanel {
         pressed = true;
         silence();
         onContinue.run();
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/DirectHostScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/DirectHostScreen.java
@@ -47,7 +47,7 @@ final class DirectHostScreen extends JPanel {
     private int endpointPort = -1;
     private List<String> endpoints = List.of();
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     DirectHostScreen(GameData data, String map, Listener listener) {
         large = GameFont.load(data, GameFont.Face.LARGE);
@@ -132,6 +132,15 @@ final class DirectHostScreen extends JPanel {
 
     int selectedPort() {
         return DirectAddress.parsePort(port);
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/FogTiles.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/FogTiles.java
@@ -80,6 +80,15 @@ public final class FogTiles {
         return levels;
     }
 
+    /** A whole square of fog, sharing the mask compositor's alpha rules. */
+    static BufferedImage full(int alpha) {
+        BufferedImage image = new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_ARGB);
+        int[] pixels = new int[SIZE * SIZE];
+        java.util.Arrays.fill(pixels, alpha << 24);
+        image.setRGB(0, 0, SIZE, SIZE, pixels, 0, SIZE);
+        return image;
+    }
+
     /**
      * One mask as black at a given alpha.
      *

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameFont.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameFont.java
@@ -100,6 +100,8 @@ final class GameFont {
     private static Font regularBase;
     private static Font boldBase;
     private static boolean loadAttempted;
+    private static final java.util.EnumMap<Face, GameFont> FACES =
+            new java.util.EnumMap<>(Face.class);
 
     /**
      * Whether anything has had to fall back to a font off the machine.
@@ -114,6 +116,7 @@ final class GameFont {
     private static boolean fellBack;
 
     private final Font font;
+    private final FontMetrics metrics;
     private final int lineHeight;
     private final int ascent;
 
@@ -121,6 +124,18 @@ final class GameFont {
         this.font = font;
         this.ascent = extent.ascent();
         this.lineHeight = extent.height();
+        // Labels used to allocate a raster and graphics context on every
+        // measurement. Metrics belong to the face and its fixed text hints,
+        // so retain them without retaining a graphics context or a surface.
+        var scratch = new java.awt.image.BufferedImage(1, 1,
+                java.awt.image.BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2 = scratch.createGraphics();
+        try {
+            applyHints(g2);
+            this.metrics = g2.getFontMetrics(font);
+        } finally {
+            g2.dispose();
+        }
     }
 
     /** What a face actually marks: where its ink starts and how tall it is. */
@@ -210,10 +225,12 @@ final class GameFont {
      * drawn in whatever the runtime has, and the fallback is a real font rather
      * than nothing.
      */
-    static GameFont load(net.chonkbase.chonkcraft.engine.GameData data, Face face) {
-        Font base = base(face.style == Font.BOLD);
-        Font sized = base.deriveFont(face.style, face.size);
-        return new GameFont(sized, measure(sized));
+    static synchronized GameFont load(net.chonkbase.chonkcraft.engine.GameData data, Face face) {
+        return FACES.computeIfAbsent(face, selected -> {
+            Font base = base(selected.style == Font.BOLD);
+            Font sized = base.deriveFont(selected.style, selected.size);
+            return new GameFont(sized, measure(sized));
+        });
     }
 
     /**
@@ -307,13 +324,7 @@ final class GameFont {
         if (text == null || text.isEmpty()) {
             return 0;
         }
-        java.awt.image.BufferedImage scratch =
-                new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2 = scratch.createGraphics();
-        applyHints(g2);
-        int width = g2.getFontMetrics(font).stringWidth(text);
-        g2.dispose();
-        return width;
+        return metrics.stringWidth(text);
     }
 
     /**
@@ -331,28 +342,20 @@ final class GameFont {
         if (text == null || text.isEmpty()) {
             return "";
         }
-        java.awt.image.BufferedImage scratch =
-                new java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2 = scratch.createGraphics();
-        try {
-            applyHints(g2);
-            FontMetrics metrics = g2.getFontMetrics(font);
-            if (metrics.stringWidth(text) <= width) {
-                return text;
-            }
-            String ellipsis = "...";
-            int room = width - metrics.stringWidth(ellipsis);
-            if (room <= 0) {
-                return "";
-            }
-            int end = text.length();
-            while (end > 0 && metrics.stringWidth(text.substring(0, end)) > room) {
-                end--;
-            }
-            return end == 0 ? "" : text.substring(0, end).stripTrailing() + ellipsis;
-        } finally {
-            g2.dispose();
+        if (metrics.stringWidth(text) <= width) {
+            return text;
         }
+        String ellipsis = "...";
+        int room = width - metrics.stringWidth(ellipsis);
+        if (room <= 0) {
+            return "";
+        }
+        int end = text.length();
+        char[] characters = text.toCharArray();
+        while (end > 0 && metrics.charsWidth(characters, 0, end) > room) {
+            end--;
+        }
+        return end == 0 ? "" : text.substring(0, end).stripTrailing() + ellipsis;
     }
 
     /**

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
@@ -547,13 +547,8 @@ final class GameScreen extends JPanel {
         }
     }
 
-    /**
-     * The visible part of the map, copied out at its own size.
-     *
-     * <p>Kept and reused rather than made each frame: it is viewport sized and
-     * allocating one a frame is work the collector then has to undo.
-     */
-    private BufferedImage terrainSlice;
+    /** Bounded terrain pictures, kept separate from unit animation frames. */
+    private final TerrainView terrainView = new TerrainView();
 
     /**
      * The tile sheet the ground was rasterised out of, and the tileset that
@@ -648,13 +643,13 @@ final class GameScreen extends JPanel {
             renderer.drawTile(groundScratch, 0, 0,
                     map.tileset().graphicFor(map.field(tileX, tileY).tile()));
             raster.setDataElements(left, top, TILE, TILE, groundScratch.pixels());
+            terrainView.invalidate(left, top, TILE, TILE);
         }
-        // A fresh view over the same pixels. The raster is shared, so the
-        // squares above are already in whatever the last cycle handed out --
-        // but that image may have an accelerated copy cached behind it, and a
-        // copy taken before the axe fell is exactly the picture this method
-        // exists to stop the player seeing.
+        // The changed pieces were invalidated above. Keep the shared raster
+        // paired with the current palette, without giving the full-map view
+        // a managed device copy of its own.
         cyclingTerrain = IndexedImage.recolour(terrain, cyclingPalette);
+        cyclingTerrain.setAccelerationPriority(0);
     }
 
     /** The tile sheet, loaded on first use, or null if it cannot be had. */
@@ -689,55 +684,14 @@ final class GameScreen extends JPanel {
         return PudMap.Tileset.valueOf(name.toUpperCase(java.util.Locale.ROOT));
     }
 
-    /**
-     * Draws the ground.
-     *
-     * <p>Not the whole map. The map is rasterised once into an image the size
-     * of the map -- four million pixels on a large one -- and colour cycling
-     * hands out a fresh view of it every few ticks with a new palette. At one
-     * to one that is a blit and costs nothing worth measuring. Under a zoom it
-     * is not: an indexed-colour image put through a scaling transform drops
-     * off the accelerated path onto the software loop, and the software loop
-     * reads every source pixel, including the nine tenths of the map that are
-     * not on the screen. That is why this appeared the day the zoom did.
-     *
-     * <p>So the visible rectangle is copied out at its own size first, which
-     * is a straight blit, and the copy is what gets scaled. The scaling then
-     * has a few hundred thousand pixels to think about instead of four
-     * million, and the copy is a plain RGB image, which is the kind the
-     * pipeline can accelerate.
-     */
+    /** Draws the current ground through bounded, reusable terrain pieces. */
     private void drawTerrain(Graphics2D g2) {
-        // Before the blit, not after: what is drawn this frame is the map as
-        // it is now, not as it was when it loaded.
         refreshChangedGround();
         BufferedImage ground = cyclingTerrain;
-        if (ground == null) {
-            return;
+        if (ground != null) {
+            terrainView.draw(g2, ground, cameraX, cameraY,
+                    visibleWorldWidth(), visibleWorldHeight());
         }
-        if (gameScale <= 1.0) {
-            // No transform to fall off, and the blit is already the fast path.
-            g2.drawImage(ground, -cameraX, -cameraY, null);
-            return;
-        }
-        int left = Math.max(0, Math.min(cameraX, ground.getWidth()));
-        int top = Math.max(0, Math.min(cameraY, ground.getHeight()));
-        int width = Math.min(visibleWorldWidth() + 1, ground.getWidth() - left);
-        int height = Math.min(visibleWorldHeight() + 1, ground.getHeight() - top);
-        if (width <= 0 || height <= 0) {
-            return;
-        }
-        if (terrainSlice == null || terrainSlice.getWidth() < width
-                || terrainSlice.getHeight() < height) {
-            terrainSlice = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        }
-        Graphics2D slice = terrainSlice.createGraphics();
-        slice.drawImage(ground, 0, 0, width, height,
-                left, top, left + width, top + height, null);
-        slice.dispose();
-        g2.drawImage(terrainSlice, left - cameraX, top - cameraY,
-                left - cameraX + width, top - cameraY + height,
-                0, 0, width, height, null);
     }
 
     /** Advances the animated palette. Called from the simulation loop. */
@@ -748,6 +702,7 @@ final class GameScreen extends JPanel {
         cyclingPalette = cyclingPalette.cycled(cyclingRanges);
         cyclingTerrain = net.chonkbase.chonkcraft.data.graphic.IndexedImage.recolour(
                 terrain, cyclingPalette);
+        cyclingTerrain.setAccelerationPriority(0);
     }
 
     /** The nine command slots, or null when the interface art is missing. */
@@ -923,6 +878,7 @@ final class GameScreen extends JPanel {
         this.cursors = GameCursors.load(data, race);
         this.cyclingRanges = cyclingRanges == null ? java.util.List.of() : cyclingRanges;
         this.cyclingPalette = palette;
+        terrain.setAccelerationPriority(0);
         this.cyclingTerrain = terrain;
         this.commandPanel = commandPanel;
         this.applier = applier;
@@ -4796,6 +4752,15 @@ final class GameScreen extends JPanel {
     }
 
     @Override
+    public void removeNotify() {
+        terrainView.clear();
+        sprites.clear();
+        dimmedFog.flush();
+        unseenFog.flush();
+        super.removeNotify();
+    }
+
+    @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         frameCounter++;
@@ -5347,6 +5312,8 @@ final class GameScreen extends JPanel {
      * <p>Only the squares on screen are considered.
      */
     private void drawFog(Graphics2D g2) {
+        boolean deviceSurface = g2.getDeviceConfiguration().getDevice().getType()
+                == java.awt.GraphicsDevice.TYPE_RASTER_SCREEN;
         int fromX = Math.max(0, cameraX / TILE);
         int fromY = Math.max(0, cameraY / TILE);
         int toX = Math.min(world.map().width() - 1,
@@ -5385,8 +5352,7 @@ final class GameScreen extends JPanel {
                     // fringe to draw. Upstream fills it with the fog colour
                     // and does not consult the masks at all
                     // (DrawFullShroudOfFog at the unseen opacity).
-                    g2.setColor(unseenColour);
-                    g2.fillRect(left, top, TILE, TILE);
+                    drawFogSquare(g2, left, top, unseenFog, unseenColour, deviceSurface);
                     continue;
                 }
 
@@ -5394,8 +5360,7 @@ final class GameScreen extends JPanel {
                     // A tileset whose sheet had no masks in it. Squares are
                     // wrong but visible, which beats no fog at all.
                     if (visibility == FogOfWar.Visibility.EXPLORED) {
-                        g2.setColor(dimmedColour);
-                        g2.fillRect(left, top, TILE, TILE);
+                        drawFogSquare(g2, left, top, dimmedFog, dimmedColour, deviceSurface);
                     }
                     continue;
                 }
@@ -5413,13 +5378,25 @@ final class GameScreen extends JPanel {
                         g2.drawImage(fogTiles.explored(fogFrame), left, top, null);
                     }
                 } else {
-                    g2.setColor(dimmedColour);
-                    g2.fillRect(left, top, TILE, TILE);
+                    drawFogSquare(g2, left, top, dimmedFog, dimmedColour, deviceSurface);
                 }
                 if (blackFrame != 0) {
                     g2.drawImage(fogTiles.unseen(blackFrame), left, top, null);
                 }
             }
+        }
+    }
+
+    private static void drawFogSquare(Graphics2D g, int x, int y, BufferedImage image,
+            Color colour, boolean deviceSurface) {
+        // Device pipelines have a fast translucent rectangle primitive. The
+        // software paint pipe instead allocates a raster per square, so its
+        // equivalent immutable image saves megabytes of allocation per frame.
+        if (deviceSurface) {
+            g.setColor(colour);
+            g.fillRect(x, y, TILE, TILE);
+        } else {
+            g.drawImage(image, x, y, null);
         }
     }
 
@@ -5438,11 +5415,14 @@ final class GameScreen extends JPanel {
      * The veil over ground the player remembers but cannot currently see, and
      * the fill over ground never seen.
      *
-     * <p>Kept as colours rather than made per square: a screen of fog is
-     * several hundred squares and it is redrawn sixty times a second.
+     * <p>A translucent fillRect can allocate a paint raster for every square.
+     * Immutable tiles avoid that allocation in software; the device path
+     * keeps its faster filled rectangles. Both use the same alpha and coverage.
      */
     private Color dimmedColour = new Color(0, 0, 0, FogOfWarSettings.DEFAULT.explored());
     private Color unseenColour = new Color(0, 0, 0, FogOfWarSettings.DEFAULT.unseen());
+    private BufferedImage dimmedFog = FogTiles.full(FogOfWarSettings.DEFAULT.explored());
+    private BufferedImage unseenFog = FogTiles.full(FogOfWarSettings.DEFAULT.unseen());
 
     /**
      * Sets how dark the fog is.
@@ -5458,6 +5438,10 @@ final class GameScreen extends JPanel {
         fogOpacity = levels;
         dimmedColour = new Color(0, 0, 0, levels.explored());
         unseenColour = new Color(0, 0, 0, levels.unseen());
+        dimmedFog.flush();
+        unseenFog.flush();
+        dimmedFog = FogTiles.full(levels.explored());
+        unseenFog = FogTiles.full(levels.unseen());
     }
 
     /** How dark the fog is, for a test that wants to check the plumbing. */
@@ -6156,16 +6140,8 @@ final class GameScreen extends JPanel {
      * player because the same rectangle is a different picture for each side
      * once the colour ramp is swapped in.
      */
-    private final java.util.Map<SpriteKey, BufferedImage> sprites =
-            new java.util.LinkedHashMap<>(256, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(
-                        java.util.Map.Entry<SpriteKey, BufferedImage> eldest) {
-                    // Eight sides' worth of frames, since the player is part
-                    // of the key now.
-                    return size() > 3072;
-                }
-            };
+    private final ImageCache<SpriteKey> sprites =
+            new ImageCache<>(3072, 64L * 1024 * 1024);
 
     /**
      * What identifies one cut frame: which sheet, which rectangle, whose

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/ImageCache.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/ImageCache.java
@@ -1,0 +1,85 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import java.awt.image.BufferedImage;
+import java.util.LinkedHashMap;
+
+/**
+ * Generated images bounded by both count and raster bytes.
+ *
+ * <p>An entry limit alone lets a resize history or large creature frames keep
+ * hundreds of megabytes. Eviction also flushes managed device copies, whose
+ * memory the heap collector cannot use to decide when it should run.
+ * Callers serialize access with painting or their own lock.
+ */
+final class ImageCache<K> {
+    private final int entryLimit;
+    private final long byteLimit;
+    private final LinkedHashMap<K, BufferedImage> images = new LinkedHashMap<>(16, 0.75f, true);
+    private long bytes;
+
+    ImageCache(int entryLimit, long byteLimit) {
+        if (entryLimit < 1 || byteLimit < 1) {
+            throw new IllegalArgumentException("image cache limits must be positive");
+        }
+        this.entryLimit = entryLimit;
+        this.byteLimit = byteLimit;
+    }
+
+    BufferedImage get(K key) {
+        return images.get(key);
+    }
+
+    /** The most recent compatible source for extending a generated texture. */
+    BufferedImage find(java.util.function.Predicate<K> compatible) {
+        for (var entry : images.reversed().entrySet()) {
+            if (compatible.test(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    void put(K key, BufferedImage image) {
+        BufferedImage previous = images.remove(key);
+        if (previous != null) {
+            bytes -= weight(previous);
+            if (previous != image) {
+                previous.flush();
+            }
+        }
+        long weight = weight(image);
+        if (weight > byteLimit) {
+            return;
+        }
+        while (!images.isEmpty()
+                && (images.size() >= entryLimit || bytes + weight > byteLimit)) {
+            BufferedImage evicted = images.pollFirstEntry().getValue();
+            bytes -= weight(evicted);
+            evicted.flush();
+        }
+        images.put(key, image);
+        bytes += weight;
+    }
+
+    void clear() {
+        images.values().forEach(BufferedImage::flush);
+        images.clear();
+        bytes = 0;
+    }
+
+    void removeIf(java.util.function.Predicate<K> changed) {
+        var entries = images.entrySet().iterator();
+        while (entries.hasNext()) {
+            var entry = entries.next();
+            if (changed.test(entry.getKey())) {
+                bytes -= weight(entry.getValue());
+                entry.getValue().flush();
+                entries.remove();
+            }
+        }
+    }
+
+    private static long weight(BufferedImage image) {
+        return 4L * image.getWidth() * image.getHeight();
+    }
+}

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/JoinScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/JoinScreen.java
@@ -83,7 +83,7 @@ final class JoinScreen extends JPanel {
     private String service = "Connecting to ChonkCraft...";
     private long lastRefresh;
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     private record Hit(Rectangle where, Runnable action) {
     }
@@ -216,6 +216,15 @@ final class JoinScreen extends JPanel {
     }
 
     static final int DEFAULT_PORT = 7100;
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
+    }
 
     @Override
     protected void paintComponent(Graphics graphics) {

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
@@ -126,7 +126,10 @@ final class LobbyScreen extends JPanel {
     private boolean starting;
 
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
+    private record Picture(GameLobby.State state, String notice, boolean starting,
+            int holding, String serviceProblem) {}
+    private Picture painted;
 
     LobbyScreen(GameData data, GameLobby lobby, String mapName, Listener listener) {
         this(data, lobby, mapName, null, listener);
@@ -147,7 +150,7 @@ final class LobbyScreen extends JPanel {
     }
 
     /**
-     * Carries the conversation on and redraws.
+     * Carries the conversation on and redraws changed information.
      *
      * <p>Driven from outside rather than by a timer of its own, so the screen
      * has one clock and not two.
@@ -172,7 +175,16 @@ final class LobbyScreen extends JPanel {
             listener.onStart(lobby);
             return;
         }
-        repaint();
+        // Network polling stays at its own cadence. An unchanged roster used
+        // to repaint the entire window twenty times a second while waiting.
+        if (!picture(lobby.state()).equals(painted)) {
+            repaint();
+        }
+    }
+
+    private Picture picture(GameLobby.State state) {
+        return new Picture(state, notice, starting, holding,
+                online == null ? "" : online.serviceProblem());
     }
 
     private void installInput() {
@@ -303,6 +315,15 @@ final class LobbyScreen extends JPanel {
     // ---- drawing ------------------------------------------------------
 
     @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
+    }
+
+    @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         if (design == null) {
@@ -354,6 +375,7 @@ final class LobbyScreen extends JPanel {
 
         drawTable(g2, state);
         drawFoot(g2, state);
+        painted = picture(state);
     }
 
     private String lobbyHeading() {

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/MenuScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/MenuScreen.java
@@ -92,7 +92,7 @@ final class MenuScreen extends JPanel {
 
     /** The menu drawn at its own size, and the scaler's working copy. */
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     private final BufferedImage background;
 
@@ -614,6 +614,15 @@ final class MenuScreen extends JPanel {
                 }
             }
         });
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/OnlineHostScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/OnlineHostScreen.java
@@ -45,7 +45,7 @@ final class OnlineHostScreen extends JPanel {
     private boolean attemptPending;
     private Timer deadline;
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     private record Hit(Rectangle where, Runnable action) {
     }
@@ -158,6 +158,15 @@ final class OnlineHostScreen extends JPanel {
 
     String detailForTest() {
         return detail;
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PixelScaler.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PixelScaler.java
@@ -1,9 +1,15 @@
 package net.chonkbase.chonkcraft.desktop;
 
+import java.awt.AlphaComposite;
 import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.Image;
+import java.awt.Transparency;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
 
 /**
  * Draws a small picture large without spoiling it.
@@ -60,13 +66,12 @@ final class PixelScaler {
     /**
      * Draws a picture to fill a window, keeping its shape unless told not to.
      *
-     * @param cache a one-slot cache for the intermediate, or null. Passing one
-     *              matters for video: a cutscene draws twelve times a second
-     *              and allocating a full-size intermediate each time is work
-     *              the collector then has to undo.
+     * @param cache the screen-owned scaling surfaces, or null. The owner flushes
+     *              them when removed so native graphics memory does not wait
+     *              for heap pressure before it can be reclaimed.
      */
-    static BufferedImage draw(Graphics2D g2, BufferedImage source,
-            int windowWidth, int windowHeight, boolean stretch, BufferedImage cache) {
+    static Cache draw(Graphics2D g2, BufferedImage source,
+            int windowWidth, int windowHeight, boolean stretch, Cache cache) {
         if (source == null || windowWidth <= 0 || windowHeight <= 0) {
             return cache;
         }
@@ -84,9 +89,9 @@ final class PixelScaler {
      * Blizzard logo tall and thin. The display aspect controls only the target
      * rectangle; the source raster remains intact.
      */
-    static BufferedImage drawAtAspect(Graphics2D g2, BufferedImage source,
+    static Cache drawAtAspect(Graphics2D g2, BufferedImage source,
             int windowWidth, int windowHeight, int aspectWidth, int aspectHeight,
-            BufferedImage cache) {
+            Cache cache) {
         if (source == null || windowWidth <= 0 || windowHeight <= 0) {
             return cache;
         }
@@ -95,8 +100,8 @@ final class PixelScaler {
         return drawInto(g2, source, target, cache, true);
     }
 
-    private static BufferedImage drawInto(Graphics2D g2, BufferedImage source,
-            Rectangle target, BufferedImage cache, boolean independentAxes) {
+    private static Cache drawInto(Graphics2D g2, BufferedImage source,
+            Rectangle target, Cache cache, boolean independentAxes) {
         // The whole-number part, done exactly.
         int prescaleX;
         int prescaleY;
@@ -114,35 +119,172 @@ final class PixelScaler {
             prescaleY = common;
         }
 
-        BufferedImage stepped = source;
-        if (prescaleX > 1 || prescaleY > 1) {
-            int width = source.getWidth() * prescaleX;
-            int height = source.getHeight() * prescaleY;
-            BufferedImage into = cache != null
-                    && cache.getWidth() == width && cache.getHeight() == height
-                    ? cache
-                    : new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-            Graphics2D into2 = into.createGraphics();
-            into2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                    RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
-            into2.drawImage(source, 0, 0, width, height, null);
-            into2.dispose();
-            stepped = into;
-            cache = into;
+        if (cache == null) {
+            cache = new Cache();
         }
-
-        // The fraction that is left, spread evenly.
-        Object interpolation = stepped.getWidth() == target.width
-                && stepped.getHeight() == target.height
-                ? RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR
-                : RenderingHints.VALUE_INTERPOLATION_BILINEAR;
+        int width = source.getWidth() * prescaleX;
+        int height = source.getHeight() * prescaleY;
         Object saved = g2.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
-        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolation);
-        g2.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g2.drawImage(stepped, target.x, target.y, target.width, target.height, null);
-        if (saved != null) {
-            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, saved);
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                width == target.width && height == target.height
+                        ? RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR
+                        : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        try {
+            if (!cache.drawAccelerated(g2, source, width, height, target)) {
+                Image stepped = source;
+                if (prescaleX > 1 || prescaleY > 1) {
+                    if (cache.software == null || cache.software.getWidth() != width
+                            || cache.software.getHeight() != height) {
+                        if (cache.software != null) {
+                            cache.software.flush();
+                        }
+                        cache.software = new BufferedImage(width, height,
+                                BufferedImage.TYPE_INT_RGB);
+                    }
+                    Graphics2D into = cache.software.createGraphics();
+                    into.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                            RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+                    into.drawImage(source, 0, 0, width, height, null);
+                    into.dispose();
+                    stepped = cache.software;
+                }
+                g2.drawImage(stepped, target.x, target.y, target.width, target.height, null);
+            }
+        } finally {
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, saved == null
+                    ? RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR : saved);
         }
         return cache;
+    }
+
+    /**
+     * At most a source upload, an integer intermediate and a software fallback.
+     *
+     * <p>A modified BufferedImage scaled directly to an accelerated destination
+     * can fall through Java2D's software transform, allocating a full-size
+     * raster on every paint. Uploading at one to one first lets both scaling
+     * passes stay on the GPU. These surfaces belong to one screen and are
+     * explicitly flushed on resize, device changes and screen removal.
+     */
+    static final class Cache {
+        private GraphicsConfiguration configuration;
+        private VolatileImage upload;
+        private VolatileImage enlarged;
+        private BufferedImage software;
+        private boolean unavailable;
+
+        private boolean drawAccelerated(Graphics2D destination, BufferedImage source,
+                int width, int height, Rectangle target) {
+            GraphicsConfiguration next = destination.getDeviceConfiguration();
+            if (next.getDevice().getType() != GraphicsDevice.TYPE_RASTER_SCREEN) {
+                return false;
+            }
+            if (configuration != next) {
+                flush();
+                configuration = next;
+            }
+            if (unavailable) {
+                return false;
+            }
+            // Volatile images inherit the device scale. Request logical sizes
+            // whose backing pixels match the art, and upload with an identity
+            // transform. Otherwise Retina uploads scale in software and the
+            // intermediate uses four times the intended storage and changes
+            // the sharp-bilinear sampling footprint.
+            var deviceScale = next.getDefaultTransform();
+            double scaleX = deviceScale.getScaleX();
+            double scaleY = deviceScale.getScaleY();
+            int sourceWidth = (int) Math.round(source.getWidth() / scaleX);
+            int sourceHeight = (int) Math.round(source.getHeight() / scaleY);
+            if (sourceWidth < 1 || sourceHeight < 1
+                    || sourceWidth * scaleX != source.getWidth()
+                    || sourceHeight * scaleY != source.getHeight()) {
+                return false;
+            }
+            int enlargedWidth = (int) Math.round(width / scaleX);
+            int enlargedHeight = (int) Math.round(height / scaleY);
+            int transparency = source.getTransparency() == Transparency.OPAQUE
+                    ? Transparency.OPAQUE : Transparency.TRANSLUCENT;
+            if (upload == null || upload.getWidth() != sourceWidth
+                    || upload.getHeight() != sourceHeight
+                    || upload.getTransparency() != transparency) {
+                releaseAccelerated();
+                upload = next.createCompatibleVolatileImage(sourceWidth, sourceHeight,
+                        transparency);
+                if (!upload.getCapabilities().isAccelerated()) {
+                    releaseAccelerated();
+                    unavailable = true;
+                    return false;
+                }
+            }
+            boolean prescaled = width != source.getWidth() || height != source.getHeight();
+            if (enlarged != null && (!prescaled || enlarged.getWidth() != enlargedWidth
+                    || enlarged.getHeight() != enlargedHeight)) {
+                enlarged.flush();
+                enlarged = null;
+            }
+            if (prescaled && enlarged == null) {
+                enlarged = next.createCompatibleVolatileImage(enlargedWidth, enlargedHeight,
+                        Transparency.OPAQUE);
+            }
+            // Surface loss can persist while a window moves between devices.
+            // Bound retries so losing acceleration cannot stall the event queue.
+            for (int attempt = 0; attempt < 3; attempt++) {
+                if (upload.validate(next) == VolatileImage.IMAGE_INCOMPATIBLE
+                        || enlarged != null
+                        && enlarged.validate(next) == VolatileImage.IMAGE_INCOMPATIBLE) {
+                    releaseAccelerated();
+                    return false;
+                }
+                Graphics2D into = upload.createGraphics();
+                into.setTransform(new java.awt.geom.AffineTransform());
+                into.setComposite(AlphaComposite.Src);
+                into.drawImage(source, 0, 0, null);
+                into.dispose();
+                Image stepped = upload;
+                if (prescaled) {
+                    into = enlarged.createGraphics();
+                    into.setTransform(new java.awt.geom.AffineTransform());
+                    into.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                            RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+                    into.drawImage(upload, 0, 0, width, height, null);
+                    into.dispose();
+                    stepped = enlarged;
+                }
+                destination.drawImage(stepped, target.x, target.y,
+                        target.width, target.height, null);
+                if (!upload.contentsLost() && (enlarged == null || !enlarged.contentsLost())) {
+                    if (software != null) {
+                        software.flush();
+                        software = null;
+                    }
+                    return true;
+                }
+            }
+            releaseAccelerated();
+            return false;
+        }
+
+        private void releaseAccelerated() {
+            if (upload != null) {
+                upload.flush();
+                upload = null;
+            }
+            if (enlarged != null) {
+                enlarged.flush();
+                enlarged = null;
+            }
+        }
+
+        /** Releases device memory even when the Java heap has plenty of room. */
+        void flush() {
+            releaseAccelerated();
+            if (software != null) {
+                software.flush();
+                software = null;
+            }
+            configuration = null;
+            unavailable = false;
+        }
     }
 }

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/ResultsScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/ResultsScreen.java
@@ -182,7 +182,7 @@ final class ResultsScreen extends JPanel {
 
     private Rectangle continueBounds;
     private BufferedImage design;
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     /**
      * @param score the figure the rank is read off: this mission's points plus
@@ -248,6 +248,15 @@ final class ResultsScreen extends JPanel {
                 }
             }
         });
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/SidePanel.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/SidePanel.java
@@ -89,6 +89,9 @@ final class SidePanel {
     /** Reused each frame rather than reallocated. */
     private final BufferedImage minimap =
             new BufferedImage(SIZE, SIZE, BufferedImage.TYPE_INT_RGB);
+    // One bulk update avoids an int array allocation for every setRGB pixel
+    // while keeping the image eligible for Java2D's managed surface cache.
+    private final int[] minimapPixels = new int[SIZE * SIZE];
 
     /** The layout the game's own scripts describe, or null if unreadable. */
     private net.chonkbase.chonkcraft.engine.ui.UiLayout.Layout layout;
@@ -550,12 +553,12 @@ final class SidePanel {
                     // nothing, which is what UiToggleTerrain
                     // The game is for on a crowded
                     // map.
-                    minimap.setRGB(x, y, 0);
+                    minimapPixels[y * SIZE + x] = 0;
                     continue;
                 }
-                minimap.setRGB(x, y, seen == FogOfWar.Visibility.UNEXPLORED
+                minimapPixels[y * SIZE + x] = seen == FogOfWar.Visibility.UNEXPLORED
                         ? veil(terrainColour(tileX, tileY, false), fogOpacity.unseen())
-                        : terrainColour(tileX, tileY, seen == FogOfWar.Visibility.EXPLORED));
+                        : terrainColour(tileX, tileY, seen == FogOfWar.Visibility.EXPLORED);
             }
         }
 
@@ -596,7 +599,7 @@ final class SidePanel {
             if (!seen || unit == withheld.unit()) {
                 continue;
             }
-            plotOnMinimap(minimap, minimapSize, mapWidth, mapHeight,
+            plotOnMinimap(minimapPixels, minimapSize, mapWidth, mapHeight,
                     unit.tileX(), unit.tileY(), unit.type(), minimapColour(unit));
         }
         // What the player remembers. The map view draws these and the minimap
@@ -606,11 +609,12 @@ final class SidePanel {
             if (!memory.type().visibleUnderFog() || memory.equals(withheld.memory())) {
                 continue;
             }
-            plotOnMinimap(minimap, minimapSize, mapWidth, mapHeight,
+            plotOnMinimap(minimapPixels, minimapSize, mapWidth, mapHeight,
                     memory.tileX(), memory.tileY(), memory.type(),
                     minimapColour(memory.owner(), memory.type(), false));
         }
 
+        minimap.setRGB(0, 0, minimapSize, minimapSize, minimapPixels, 0, SIZE);
         g2.drawImage(minimap, minimapX, minimapY, null);
 
         // The viewport rectangle, so the player can see where they are.
@@ -746,7 +750,7 @@ final class SidePanel {
      * buildings. A four by four keep and a footman used to be the same mark,
      * and a town read as a scattering of pairs.
      */
-    private static void plotOnMinimap(java.awt.image.BufferedImage minimap, int minimapSize,
+    private static void plotOnMinimap(int[] pixels, int minimapSize,
             int mapWidth, int mapHeight, int tileX, int tileY, UnitType type, int colour) {
         int x = tileX * minimapSize / mapWidth;
         int y = tileY * minimapSize / mapHeight;
@@ -757,7 +761,7 @@ final class SidePanel {
         int down = Math.max(1, Math.max(1, type.tileHeight()) * minimapSize / mapHeight);
         for (int dy = 0; dy < down && y + dy < minimapSize; dy++) {
             for (int dx = 0; dx < across && x + dx < minimapSize; dx++) {
-                minimap.setRGB(x + dx, y + dy, colour);
+                pixels[(y + dy) * SIZE + x + dx] = colour;
             }
         }
     }

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/SplashScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/SplashScreen.java
@@ -47,7 +47,7 @@ final class SplashScreen extends JPanel {
     private final net.chonkbase.runtime.audio.PcmClip sound;
 
     /** The scaler's intermediate, kept so a resize does not reallocate it. */
-    private BufferedImage cache;
+    private PixelScaler.Cache cache;
 
     /**
      * @param seconds how long to stay up; zero waits for a key
@@ -115,6 +115,15 @@ final class SplashScreen extends JPanel {
         if (onFinished != null) {
             onFinished.run();
         }
+    }
+
+    @Override
+    public void removeNotify() {
+        if (cache != null) {
+            cache.flush();
+            cache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/StoneTexture.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/StoneTexture.java
@@ -1,8 +1,6 @@
 package net.chonkbase.chonkcraft.desktop;
 
 import java.awt.image.BufferedImage;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * The interface's stone, generated rather than scanned.
@@ -48,13 +46,10 @@ final class StoneTexture {
      */
     private static final int CACHE_LIMIT = 48;
 
-    private static final Map<String, BufferedImage> CACHE =
-            new LinkedHashMap<>(16, 0.75f, true) {
-                @Override
-                protected boolean removeEldestEntry(Map.Entry<String, BufferedImage> eldest) {
-                    return size() > CACHE_LIMIT;
-                }
-            };
+    private record Key(int width, int height, Tint tint, double scale) {}
+
+    private static final ImageCache<Key> CACHE =
+            new ImageCache<>(CACHE_LIMIT, 32L * 1024 * 1024);
 
     private StoneTexture() {
     }
@@ -88,12 +83,14 @@ final class StoneTexture {
         double factor = scale <= 0 ? 1.0 : Math.min(MAX_SCALE, scale);
         int pixelWidth = Math.max(1, (int) Math.round(width * factor));
         int pixelHeight = Math.max(1, (int) Math.round(height * factor));
-        String key = pixelWidth + "x" + pixelHeight + ":" + tint + ":" + factor;
+        Key key = new Key(pixelWidth, pixelHeight, tint, factor);
         BufferedImage found = CACHE.get(key);
         if (found != null) {
             return found;
         }
-        BufferedImage made = generate(pixelWidth, pixelHeight, tint, factor);
+        BufferedImage previous = CACHE.find(candidate -> candidate.tint() == tint
+                && candidate.scale() == factor);
+        BufferedImage made = generate(pixelWidth, pixelHeight, tint, factor, previous);
         CACHE.put(key, made);
         return made;
     }
@@ -116,15 +113,27 @@ final class StoneTexture {
      */
     private static final double GRAIN = 26.0;
 
-    private static BufferedImage generate(int width, int height, Tint tint, double scale) {
+    private static BufferedImage generate(int width, int height, Tint tint, double scale,
+            BufferedImage previous) {
         BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-        int[] pixels = new int[width * height];
+        int[] pixels = new int[width];
+        int copiedWidth = previous == null ? 0 : Math.min(width, previous.getWidth());
+        int copiedHeight = previous == null ? 0 : Math.min(height, previous.getHeight());
+        if (previous != null) {
+            // Grain depends on coordinates, tint and scale, never the slab's
+            // extent. A one-pixel resize used to recompute every octave across
+            // the whole panel; only newly exposed rows and columns need noise.
+            var into = image.createGraphics();
+            into.drawImage(previous, 0, 0, null);
+            into.dispose();
+        }
 
         // The grain is enlarged with the slab, so a panel drawn twice the size
         // is the same stone seen closer rather than a finer-grained stone.
         double grain = GRAIN * scale;
         for (int y = 0; y < height; y++) {
-            for (int x = 0; x < width; x++) {
+            int fromX = y < copiedHeight ? copiedWidth : 0;
+            for (int x = fromX; x < width; x++) {
                 double u = x / grain;
                 double v = y / grain;
 
@@ -164,10 +173,13 @@ final class StoneTexture {
                         - seam * 0.16
                         + grit * 0.13
                         + fine * 0.10);
-                pixels[y * width + x] = colour(shade, tint);
+                pixels[x] = colour(shade, tint);
+            }
+            if (fromX < width) {
+                image.setRGB(fromX, y, width - fromX, 1, pixels, fromX, width);
             }
         }
-        image.setRGB(0, 0, width, height, pixels, 0, width);
+
         return image;
     }
 

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/TerrainView.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/TerrainView.java
@@ -1,0 +1,222 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+
+/**
+ * Immutable, bounded pieces of the visible terrain.
+ *
+ * <p>A changing full-map palette view can acquire a full-map device texture;
+ * repeatedly uploading a viewport avoids that retention but stalls on large
+ * displays. Small immutable pieces let Java2D retain useful device copies.
+ * Only colours actually used in a piece participate in its cache key, so
+ * water cycling does not invalidate grass and returning palette phases reuse
+ * their pictures. The original indexed map remains the source of truth.
+ */
+final class TerrainView {
+    // Large enough to keep draw submission modest, with at most a one MiB
+    // raster to upload when a piece changes. The byte bound also covers all
+    // retained palette phases, rather than charging only the current one.
+    private static final int SIZE = 512;
+    private static final int LIMIT = 512;
+    private final ImageCache<Key> pictures = new ImageCache<>(LIMIT, 32L * 1024 * 1024);
+    private final LinkedHashMap<Integer, Piece> pieces = new LinkedHashMap<>(64, .75f, true);
+    private int[] samples;
+    private int[] pixels;
+    private int[] colours;
+    private IndexColorModel expandedPalette;
+    private java.awt.GraphicsConfiguration uploadConfiguration;
+    private java.awt.image.VolatileImage uploadPrimer;
+
+    void draw(Graphics2D g, BufferedImage ground, int cameraX, int cameraY, int width, int height) {
+        if (!(ground.getColorModel() instanceof IndexColorModel palette)) {
+            g.drawImage(ground, -cameraX, -cameraY, null);
+            return;
+        }
+        if (samples == null) {
+            samples = new int[SIZE * SIZE];
+            pixels = new int[SIZE * SIZE];
+        }
+        if (expandedPalette != palette) {
+            if (colours == null || colours.length != (1 << palette.getPixelSize())) {
+                colours = new int[1 << palette.getPixelSize()];
+            }
+            for (int index = 0; index < colours.length; index++) {
+                int argb = palette.getRGB(index);
+                int alpha = argb >>> 24;
+                // Terrain is composited over black, including transparent
+                // index 255. Preserve that rule when expanding into RGB.
+                int red = ((argb >> 16 & 255) * alpha + 127) / 255;
+                int green = ((argb >> 8 & 255) * alpha + 127) / 255;
+                int blue = ((argb & 255) * alpha + 127) / 255;
+                colours[index] = red << 16 | green << 8 | blue;
+            }
+            expandedPalette = palette;
+        }
+        int fromX = Math.max(0, Math.floorDiv(cameraX, SIZE));
+        int fromY = Math.max(0, Math.floorDiv(cameraY, SIZE));
+        int toX = Math.min((ground.getWidth() - 1) / SIZE, (cameraX + width) / SIZE);
+        int toY = Math.min((ground.getHeight() - 1) / SIZE, (cameraY + height) / SIZE);
+        for (int y = fromY; y <= toY; y++) {
+            for (int x = fromX; x <= toX; x++) {
+                int index = y * ((ground.getWidth() + SIZE - 1) / SIZE) + x;
+                Piece piece = pieces.get(index);
+                if (piece == null) {
+                    piece = new Piece(ground, x * SIZE, y * SIZE, samples);
+                    if (pieces.size() == LIMIT) {
+                        Piece old = pieces.pollFirstEntry().getValue();
+                        pictures.removeIf(key -> key.piece == old);
+                    }
+                    pieces.put(index, piece);
+                }
+                Key key = piece.key(palette);
+                BufferedImage image = pictures.get(key);
+                if (image == null) {
+                    image = new BufferedImage(piece.width, piece.height, BufferedImage.TYPE_INT_RGB);
+                    // The indexed image has a transparent palette entry.
+                    // Java2D's general compositing blit made a changing sea
+                    // spend tens of milliseconds expanding one palette phase.
+                    // A lookup and bulk raster write avoid that compositing
+                    // path without making the immutable RGB image untrackable.
+                    ground.getRaster().getSamples(piece.x, piece.y, piece.width, piece.height,
+                            0, samples);
+                    for (int pixel = 0; pixel < piece.width * piece.height; pixel++) {
+                        pixels[pixel] = colours[samples[pixel]];
+                    }
+                    image.getRaster().setDataElements(0, 0, piece.width, piece.height, pixels);
+                    pictures.put(key, image);
+                    primeUpload(g, image);
+                }
+                g.drawImage(image, piece.x - cameraX, piece.y - cameraY, null);
+            }
+        }
+    }
+
+    /** Changed terrain must replace every cached palette phase of its piece. */
+    void invalidate(int x, int y, int width, int height) {
+        var entries = pieces.values().iterator();
+        while (entries.hasNext()) {
+            Piece piece = entries.next();
+            if (piece.x < x + width && piece.x + piece.width > x
+                    && piece.y < y + height && piece.y + piece.height > y) {
+                pictures.removeIf(key -> key.piece == piece);
+                entries.remove();
+            }
+        }
+    }
+
+    void clear() {
+        pictures.clear();
+        pieces.clear();
+        samples = null;
+        pixels = null;
+        colours = null;
+        expandedPalette = null;
+        if (uploadPrimer != null) {
+            uploadPrimer.flush();
+            uploadPrimer = null;
+        }
+        uploadConfiguration = null;
+    }
+
+    private void primeUpload(Graphics2D destination, BufferedImage image) {
+        var configuration = destination.getDeviceConfiguration();
+        if (configuration.getDevice().getType() != java.awt.GraphicsDevice.TYPE_RASTER_SCREEN) {
+            return;
+        }
+        if (uploadPrimer == null || uploadConfiguration != configuration) {
+            if (uploadPrimer != null) {
+                uploadPrimer.flush();
+            }
+            uploadConfiguration = configuration;
+            uploadPrimer = configuration.createCompatibleVolatileImage(1, 1, java.awt.Transparency.OPAQUE);
+        }
+        if (uploadPrimer.validate(configuration) == java.awt.image.VolatileImage.IMAGE_INCOMPATIBLE) {
+            uploadPrimer.flush();
+            uploadPrimer = null;
+            return;
+        }
+        // Managed images normally wait one copy before uploading. Make that
+        // first copy a clipped, unscaled blit, so the first visible zoomed
+        // water frame can use a texture instead of a full software transform.
+        Graphics2D into = uploadPrimer.createGraphics();
+        into.setTransform(new java.awt.geom.AffineTransform());
+        into.drawImage(image, 0, 0, null);
+        into.dispose();
+    }
+
+    private static final class Piece {
+        private final int x;
+        private final int y;
+        private final int width;
+        private final int height;
+        private final int[] used;
+        private IndexColorModel palette;
+        private Key lastKey;
+
+        Piece(BufferedImage ground, int x, int y, int[] samples) {
+            this.x = x;
+            this.y = y;
+            width = Math.min(SIZE, ground.getWidth() - x);
+            height = Math.min(SIZE, ground.getHeight() - y);
+            boolean[] seen = new boolean[1 << ground.getColorModel().getPixelSize()];
+            int count = 0;
+            // getSamples supports both byte-indexed and packed indexed art.
+            ground.getRaster().getSamples(x, y, width, height, 0, samples);
+            for (int pixel = 0; pixel < width * height; pixel++) {
+                int sample = samples[pixel];
+                if (!seen[sample]) {
+                    seen[sample] = true;
+                    count++;
+                }
+            }
+            used = new int[count];
+            int at = 0;
+            for (int index = 0; index < seen.length; index++) {
+                if (seen[index]) {
+                    used[at++] = index;
+                }
+            }
+        }
+
+        Key key(IndexColorModel next) {
+            if (palette != next) {
+                int[] colours = new int[used.length];
+                for (int index = 0; index < used.length; index++) {
+                    colours[index] = next.getRGB(used[index]);
+                }
+                if (lastKey == null || !Arrays.equals(lastKey.colours, colours)) {
+                    lastKey = new Key(this, colours);
+                }
+                palette = next;
+            }
+            return lastKey;
+        }
+    }
+
+    private static final class Key {
+        private final Piece piece;
+        private final int[] colours;
+        private final int hash;
+
+        Key(Piece piece, int[] colours) {
+            this.piece = piece;
+            this.colours = colours;
+            hash = 31 * System.identityHashCode(piece) + Arrays.hashCode(colours);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Key key && piece == key.piece
+                    && Arrays.equals(colours, key.colours);
+        }
+    }
+}

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/VideoScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/VideoScreen.java
@@ -33,7 +33,7 @@ final class VideoScreen extends JPanel {
     private final Timer timer;
 
     /** The intermediate the scaler works through, kept between frames. */
-    private BufferedImage scaleCache;
+    private PixelScaler.Cache scaleCache;
 
     /** The soundtrack, once decoded, or null when there is none. */
     private final ScreenAudio track;
@@ -227,6 +227,15 @@ final class VideoScreen extends JPanel {
         // music: skipping means leaving, and leaving means silence.
         track.silence();
         onFinished.run();
+    }
+
+    @Override
+    public void removeNotify() {
+        if (scaleCache != null) {
+            scaleCache.flush();
+            scaleCache = null;
+        }
+        super.removeNotify();
     }
 
     @Override

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/GameFontTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/GameFontTest.java
@@ -116,4 +116,30 @@ class GameFontTest {
         assertTrue(font.widthOf("Peasant the Elder") > font.widthOf("Peasant"),
                 "measurement does not grow with the string");
     }
+
+    @Test
+    @DisplayName("fitted labels keep the same letters at every available width")
+    void fittingPreservesWidthsAndComplexText() {
+        for (GameFont.Face face : GameFont.Face.values()) {
+            GameFont font = GameFont.load(null, face);
+            for (String text : new String[] {"A long multiplayer lobby name", "Gold: 1200",
+                    "   spaced name   ", "Caf\u00e9 \u6771\u4eac", "e\u0301l\u00e8ve",
+                    "\u0627\u0644\u0639\u0631\u0628\u064a\u0629", "Map \ud83c\udf0d name"}) {
+                for (int width = -1; width <= 200; width++) {
+                    String expected = text;
+                    if (font.widthOf(text) > width) {
+                        int room = width - font.widthOf("...");
+                        int end = text.length();
+                        while (end > 0 && font.widthOf(text.substring(0, end)) > room) {
+                            end--;
+                        }
+                        expected = room <= 0 || end == 0
+                                ? "" : text.substring(0, end).stripTrailing() + "...";
+                    }
+                    assertEquals(expected, font.fitted(text, width),
+                            face + " label at width " + width + ": " + text);
+                }
+            }
+        }
+    }
 }

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/ImageCacheTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/ImageCacheTest.java
@@ -1,0 +1,80 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ImageCacheTest {
+    private static final class Picture extends BufferedImage {
+        private boolean flushed;
+
+        Picture(int size) {
+            super(size, size, BufferedImage.TYPE_INT_RGB);
+            setRGB(0, 0, 0x123456);
+        }
+
+        @Override
+        public void flush() {
+            flushed = true;
+            super.flush();
+        }
+    }
+
+    @Test
+    @DisplayName("large pictures evict old device copies before the entry limit")
+    void bytesBoundTheCache() {
+        ImageCache<String> cache = new ImageCache<>(48, 800);
+        Picture old = new Picture(10);
+        Picture recent = new Picture(10);
+        Picture next = new Picture(10);
+        cache.put("old", old);
+        cache.put("recent", recent);
+        cache.get("old");
+        cache.put("next", next);
+        assertNull(cache.get("recent"), "the least recently used picture exceeds the byte budget");
+        assertTrue(recent.flushed, "native storage must be released at eviction");
+        assertSame(old, cache.get("old"), "drawing a picture keeps it recent");
+        assertSame(next, cache.get("next"), "the new picture must remain available");
+        assertEquals(0xFF123456, recent.getRGB(0, 0), "eviction preserves drawable source pixels");
+    }
+
+    @Test
+    @DisplayName("replacing and leaving a screen release its generated pictures")
+    void replacementAndClearReleaseSurfaces() {
+        ImageCache<String> cache = new ImageCache<>(2, 8000);
+        Picture old = new Picture(10);
+        Picture replacement = new Picture(10);
+        Picture second = new Picture(10);
+        cache.put("frame", old);
+        cache.put("frame", replacement);
+        assertTrue(old.flushed, "replaced frames must not wait for a heap collection");
+        cache.put("other", second);
+        cache.clear();
+        assertNull(cache.get("frame"), "leaving the screen must drop the cache");
+        assertTrue(replacement.flushed && second.flushed, "clear releases every device copy");
+        cache.put("again", old);
+        assertSame(old, cache.get("again"), "the same cache can be used after a return");
+    }
+
+    @Test
+    @DisplayName("small pictures obey the entry limit and oversized ones are not retained")
+    void entryLimitAndOversizedPictures() {
+        ImageCache<String> cache = new ImageCache<>(1, 400);
+        Picture first = new Picture(5);
+        Picture second = new Picture(5);
+        cache.put("first", first);
+        cache.put("second", second);
+        assertNull(cache.get("first"), "small images still obey the count bound");
+        assertTrue(first.flushed, "count eviction must release native storage too");
+        Picture oversized = new Picture(11);
+        cache.put("large", oversized);
+        assertNull(cache.get("large"), "one picture cannot defeat the byte budget");
+        assertSame(second, cache.get("second"), "uncacheable pictures do not evict useful frames");
+        assertEquals(0xFF123456, oversized.getRGB(0, 0), "oversized pictures can still be drawn");
+    }
+}

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
@@ -70,6 +70,41 @@ class LobbyScreenTest {
     }
 
     @Test
+    @DisplayName("an idle lobby polls without redrawing until its roster changes")
+    void idlePollingDoesNotRedrawTheScreen() throws Exception {
+        try (GameLobby lobby = GameLobby.host("Host", "garden.pud", 8, 0)) {
+            LobbyScreen screen = new LobbyScreen(null, lobby, "garden.pud", new Recording());
+            screen.setSize(640, 480);
+            screen.render();
+            AtomicInteger repaints = new AtomicInteger();
+            javax.swing.RepaintManager previous = javax.swing.RepaintManager.currentManager(screen);
+            javax.swing.RepaintManager.setCurrentManager(new javax.swing.RepaintManager() {
+                @Override
+                public void addDirtyRegion(javax.swing.JComponent component,
+                        int x, int y, int width, int height) {
+                    if (component == screen) {
+                        repaints.incrementAndGet();
+                    }
+                }
+            });
+            try {
+                for (int tick = 0; tick < 5; tick++) {
+                    screen.tick();
+                }
+                assertEquals(0, repaints.get(), "unchanged network polls should not repaint the lobby");
+                lobby.setOccupant(1, GameLobby.Occupant.COMPUTER);
+                screen.tick();
+                assertEquals(1, repaints.get(), "a changed slot must be shown on the next poll");
+                screen.render();
+                screen.tick();
+                assertEquals(1, repaints.get(), "a painted roster should become idle again");
+            } finally {
+                javax.swing.RepaintManager.setCurrentManager(previous);
+            }
+        }
+    }
+
+    @Test
     @DisplayName("A direct build mismatch leaves the lobby through the launcher update action")
     void aDirectMismatchOffersQuitToUpdate() throws Exception {
         String previous = System.getProperty("chonkcraft.network.build");

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PixelScalerDisplayCheck.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PixelScalerDisplayCheck.java
@@ -1,0 +1,122 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.awt.image.VolatileImage;
+import javax.swing.SwingUtilities;
+
+/** Explicit display check for the accelerated path; see docs/render-performance.md. */
+public final class PixelScalerDisplayCheck {
+    private PixelScalerDisplayCheck() {}
+
+    public static void main(String[] args) throws Exception {
+        SwingUtilities.invokeAndWait(PixelScalerDisplayCheck::check);
+    }
+
+    private static void check() {
+        var configuration = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
+        VolatileImage output = configuration.createCompatibleVolatileImage(257, 193, Transparency.OPAQUE);
+        if (!output.getCapabilities().isAccelerated()) {
+            throw new IllegalStateException("the display check needs accelerated Java2D surfaces");
+        }
+        BufferedImage source = new BufferedImage(32, 24, BufferedImage.TYPE_INT_RGB);
+        PixelScaler.Cache accelerated = null;
+        VolatileImage control = configuration.createCompatibleVolatileImage(257, 193, Transparency.OPAQUE);
+        int largestDifference = 0;
+        try {
+            for (int frame = 0; frame < 40; frame++) {
+                for (int y = 0; y < 24; y++) {
+                    for (int x = 0; x < 32; x++) {
+                        source.setRGB(x, y, ((x * 17 + frame * 23) & 255) << 16
+                                | ((y * 29 + frame * 7) & 255) << 8 | ((x + y + frame) * 13 & 255));
+                    }
+                }
+                int width = 73 + frame * 3;
+                int height = 55 + frame * 2;
+                boolean movie = frame >= 20;
+                BufferedImage picture = movie ? source.getSubimage(0, 0, 32, 14) : source;
+                control.validate(configuration);
+                Graphics2D reference = control.createGraphics();
+                reference.setColor(Color.BLACK);
+                reference.fillRect(0, 0, 257, 193);
+                legacyDraw(reference, picture, width, height, movie);
+                reference.dispose();
+                BufferedImage expected = control.getSnapshot();
+                if (output.validate(configuration) == VolatileImage.IMAGE_INCOMPATIBLE) {
+                    throw new IllegalStateException("display changed during the check");
+                }
+                Graphics2D g = output.createGraphics();
+                g.setColor(Color.BLACK);
+                g.fillRect(0, 0, 257, 193);
+                g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                        RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+                accelerated = movie
+                        ? PixelScaler.drawAtAspect(g, picture, width, height, 4, 3, accelerated)
+                        : PixelScaler.draw(g, picture, width, height, false, accelerated);
+                g.dispose();
+                if (output.contentsLost()) {
+                    throw new IllegalStateException("display contents lost during capture; rerun the check");
+                }
+                BufferedImage actual = output.getSnapshot();
+                for (int y = 0; y < 193; y++) {
+                    for (int x = 0; x < 257; x++) {
+                        int wanted = expected.getRGB(x, y);
+                        int got = actual.getRGB(x, y);
+                        for (int shift = 0; shift <= 16; shift += 8) {
+                            int difference = Math.abs((wanted >> shift & 255) - (got >> shift & 255));
+                            largestDifference = Math.max(largestDifference, difference);
+                            if (difference > 2) {
+                                throw new AssertionError("scaled frame " + frame + " differs at "
+                                        + x + "," + y + " by " + difference + " in a colour channel");
+                            }
+                        }
+                    }
+                }
+                if (frame % 3 == 0) {
+                    accelerated.flush();
+                }
+            }
+            System.out.println("accelerated_frames=40 largest_channel_difference=" + largestDifference);
+        } finally {
+            if (accelerated != null) {
+                accelerated.flush();
+            }
+            control.flush();
+            output.flush();
+        }
+    }
+    private static void legacyDraw(Graphics2D g, BufferedImage source, int width, int height,
+            boolean movie) {
+        var target = PixelScaler.fit(movie ? 4 : source.getWidth(), movie ? 3 : source.getHeight(),
+                width, height, false);
+        int scaleX = Math.max(1, Math.min(8, target.width / source.getWidth()));
+        int scaleY = Math.max(1, Math.min(8, target.height / source.getHeight()));
+        if (!movie) {
+            scaleX = scaleY = Math.min(scaleX, scaleY);
+        }
+        BufferedImage stepped = source;
+        if (scaleX > 1 || scaleY > 1) {
+            stepped = new BufferedImage(source.getWidth() * scaleX, source.getHeight() * scaleY,
+                    BufferedImage.TYPE_INT_RGB);
+            Graphics2D into = stepped.createGraphics();
+            into.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+            into.drawImage(source, 0, 0, stepped.getWidth(), stepped.getHeight(), null);
+            into.dispose();
+        }
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                stepped.getWidth() == target.width && stepped.getHeight() == target.height
+                        ? RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR
+                        : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(stepped, target.x, target.y, target.width, target.height, null);
+        if (stepped != source) {
+            stepped.flush();
+        }
+    }
+
+}

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PixelScalerTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PixelScalerTest.java
@@ -1,0 +1,112 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PixelScalerTest {
+    @Test
+    @DisplayName("menus keep sharp pixel edges and their black bars at every scale")
+    void sharpScalingKeepsThePicture() {
+        BufferedImage source = picture();
+        for (int[] size : new int[][] {{7, 6}, {13, 9}, {26, 18}, {47, 32}, {120, 95}}) {
+            for (boolean stretch : new boolean[] {false, true}) {
+                BufferedImage actual = new BufferedImage(size[0], size[1], BufferedImage.TYPE_INT_RGB);
+                Graphics2D g = actual.createGraphics();
+                PixelScaler.Cache cache = PixelScaler.draw(g, source, size[0], size[1], stretch, null);
+                g.dispose();
+                assertArrayEquals(pixels(reference(source, size[0], size[1], stretch, 13, 9, false)),
+                        pixels(actual), "menu shape at " + size[0] + "x" + size[1] + ": " + stretch);
+                cache.flush();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("movie pixels keep their intended display aspect")
+    void movieAspectKeepsBothScalingPasses() {
+        BufferedImage source = picture().getSubimage(0, 0, 13, 4);
+        BufferedImage actual = new BufferedImage(80, 70, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = actual.createGraphics();
+        PixelScaler.Cache cache = PixelScaler.drawAtAspect(g, source, 80, 70, 4, 3, null);
+        g.dispose();
+        assertArrayEquals(pixels(reference(source, 80, 70, false, 4, 3, true)), pixels(actual),
+                "non-square movie samples must retain their separate integer scales");
+        cache.flush();
+    }
+
+    @Test
+    @DisplayName("changed pictures and resized screens never reuse old pixels")
+    void repaintResizeAndReleaseKeepFreshPixels() {
+        BufferedImage source = picture();
+        PixelScaler.Cache cache = null;
+        for (int size : new int[] {39, 65, 26, 39}) {
+            BufferedImage actual = new BufferedImage(size, size, BufferedImage.TYPE_INT_RGB);
+            Graphics2D ink = source.createGraphics();
+            ink.setColor(new Color(size * 3, 80, 200 - size));
+            ink.fillRect(0, 0, 13, 9);
+            ink.dispose();
+            Graphics2D g = actual.createGraphics();
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            cache = PixelScaler.draw(g, source, size, size, true, cache);
+            assertEquals(RenderingHints.VALUE_INTERPOLATION_BICUBIC,
+                    g.getRenderingHint(RenderingHints.KEY_INTERPOLATION), "painting restores the caller's hint");
+            g.dispose();
+            assertArrayEquals(pixels(reference(source, size, size, true, 13, 9, false)), pixels(actual),
+                    "a reused surface must show the latest frame");
+            if (size == 26) {
+                cache.flush();
+            }
+        }
+        cache.flush();
+    }
+
+    private static BufferedImage picture() {
+        BufferedImage image = new BufferedImage(13, 9, BufferedImage.TYPE_INT_RGB);
+        for (int y = 0; y < 9; y++) {
+            for (int x = 0; x < 13; x++) {
+                image.setRGB(x, y, (x * 19 << 16) | (y * 29 << 8) | ((x + y) * 11));
+            }
+        }
+        return image;
+    }
+
+    private static int[] pixels(BufferedImage image) {
+        return image.getRGB(0, 0, image.getWidth(), image.getHeight(), null, 0, image.getWidth());
+    }
+
+    // The two Java2D passes used before accelerated screen-owned surfaces.
+    private static BufferedImage reference(BufferedImage source, int width, int height,
+            boolean stretch, int aspectWidth, int aspectHeight, boolean independent) {
+        var target = PixelScaler.fit(aspectWidth, aspectHeight, width, height, stretch);
+        int scaleX = Math.max(1, Math.min(8, target.width / source.getWidth()));
+        int scaleY = Math.max(1, Math.min(8, target.height / source.getHeight()));
+        if (!independent) {
+            scaleX = scaleY = Math.min(scaleX, scaleY);
+        }
+        BufferedImage stepped = source;
+        if (scaleX > 1 || scaleY > 1) {
+            stepped = new BufferedImage(source.getWidth() * scaleX, source.getHeight() * scaleY,
+                    BufferedImage.TYPE_INT_RGB);
+            Graphics2D into = stepped.createGraphics();
+            into.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                    RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+            into.drawImage(source, 0, 0, stepped.getWidth(), stepped.getHeight(), null);
+            into.dispose();
+        }
+        BufferedImage result = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = result.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(stepped, target.x, target.y, target.width, target.height, null);
+        g.dispose();
+        return result;
+    }
+}

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/RenderBenchmark.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/RenderBenchmark.java
@@ -1,0 +1,314 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Locale;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import net.chonkbase.chonkcraft.data.map.PudMap;
+import net.chonkbase.chonkcraft.data.map.PudReader;
+import net.chonkbase.chonkcraft.data.source.AssetSource;
+import net.chonkbase.chonkcraft.engine.GameData;
+import net.chonkbase.chonkcraft.engine.Player;
+import net.chonkbase.chonkcraft.engine.World;
+import net.chonkbase.chonkcraft.engine.map.GameMap;
+import net.chonkbase.chonkcraft.engine.map.MapRenderer;
+import net.chonkbase.chonkcraft.engine.network.GameLobby;
+import net.chonkbase.chonkcraft.engine.network.SyncHash;
+
+/**
+ * Reproducible paint, allocation and graphics-lifetime measurements.
+ *
+ * <p>Run explicitly, never as a wall-clock assertion in the unit suite. The
+ * display mode paints to a real Java2D surface and synchronizes submission;
+ * it measures painting cost, not scanout or input-to-photon latency. No game
+ * saves, recordings, preferences or external network peers are created.
+ * See docs/render-performance.md for commands and comparison conditions.
+ */
+public final class RenderBenchmark {
+    private static final com.sun.management.ThreadMXBean THREADS =
+            (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+    private static int frames = 180;
+    private static int warmup = 40;
+    private static int width = 2560;
+    private static int height = 1600;
+    private static int sessions = 30;
+    private static int battleUnits;
+    private static JFrame window;
+    private static BufferedImage canvas;
+    private static JPanel current;
+    private static long witness;
+
+    private RenderBenchmark() {}
+
+    public static void main(String[] args) throws Exception {
+        boolean display = Arrays.asList(args).contains("--display");
+        String mode = "all";
+        for (String arg : args) {
+            if (arg.startsWith("--frames=")) {
+                frames = positive(arg);
+            } else if (arg.startsWith("--warmup=")) {
+                warmup = positive(arg);
+            } else if (arg.startsWith("--width=")) {
+                width = positive(arg);
+            } else if (arg.startsWith("--height=")) {
+                height = positive(arg);
+            } else if (arg.startsWith("--sessions=")) {
+                sessions = positive(arg);
+            } else if (arg.startsWith("--battle=")) {
+                battleUnits = positive(arg);
+            } else if (arg.startsWith("--mode=")) {
+                mode = arg.substring(arg.indexOf('=') + 1);
+            } else if (!arg.equals("--display")) {
+                throw new IllegalArgumentException("unknown benchmark argument: " + arg);
+            }
+        }
+        if (!Arrays.asList("all", "menus", "game", "stone", "soak").contains(mode)) {
+            throw new IllegalArgumentException("mode must be all, menus, game, stone or soak");
+        }
+        System.out.printf(Locale.ROOT, "java=%s os=%s arch=%s max_heap_MiB=%d display=%s size=%dx%d%n",
+                System.getProperty("java.runtime.version"), System.getProperty("os.name"),
+                System.getProperty("os.arch"), Runtime.getRuntime().maxMemory() / 1048576,
+                display, width, height);
+        GameData data = mode.equals("stone") ? null : new GameData(AssetSource.fromEnvironment());
+        String selected = mode;
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    if (display) {
+                        window = new JFrame("ChonkCraft rendering benchmark");
+                        window.setSize(width, height);
+                        window.setVisible(true);
+                        System.out.println("graphics=" + window.getGraphicsConfiguration());
+                    }
+                    if (selected.equals("all") || selected.equals("menus")) {
+                        menus(data);
+                    }
+                    if (selected.equals("all") || selected.equals("game")) {
+                        game(data);
+                    }
+                    if (selected.equals("all") || selected.equals("stone")) {
+                        stone();
+                    }
+                } catch (Exception failed) {
+                    throw new RuntimeException(failed);
+                }
+            });
+            if (selected.equals("soak")) {
+                soak(data);
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                current = null;
+                if (canvas != null) {
+                    canvas.flush();
+                    canvas = null;
+                }
+                if (window != null) {
+                    window.dispose();
+                }
+            });
+        }
+        SwingUtilities.invokeAndWait(() -> {});
+        System.gc();
+        System.out.printf(Locale.ROOT, "heap_after_gc_MiB=%d witness=%016x%n",
+                ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1048576, witness);
+    }
+
+    private static int positive(String arg) {
+        int value = Integer.parseInt(arg.substring(arg.indexOf('=') + 1));
+        if (value <= 0) {
+            throw new IllegalArgumentException("benchmark values must be positive: " + arg);
+        }
+        return value;
+    }
+
+    private static void attach(JPanel panel) {
+        current = panel;
+        panel.setPreferredSize(new Dimension(width, height));
+        panel.setSize(width, height);
+        if (window != null) {
+            window.setContentPane(panel);
+            window.pack();
+            window.validate();
+        } else if (canvas == null) {
+            canvas = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        }
+        paint();
+    }
+
+    private static void paint() {
+        Graphics2D g = window == null ? canvas.createGraphics() : (Graphics2D) current.getGraphics();
+        try {
+            current.paint(g);
+        } finally {
+            g.dispose();
+        }
+        if (window != null) {
+            Toolkit.getDefaultToolkit().sync();
+        }
+    }
+
+    private static void measure(String name, Runnable action) {
+        measure(name, action, warmup, frames);
+    }
+
+    private static void measure(String name, Runnable action, int warm, int count) {
+        for (int frame = 0; frame < warm; frame++) {
+            action.run();
+        }
+        long[] times = new long[count];
+        long thread = Thread.currentThread().threadId();
+        long allocated = THREADS.getThreadAllocatedBytes(thread);
+        for (int frame = 0; frame < count; frame++) {
+            long start = System.nanoTime();
+            action.run();
+            times[frame] = System.nanoTime() - start;
+        }
+        allocated = THREADS.getThreadAllocatedBytes(thread) - allocated;
+        Arrays.sort(times);
+        System.out.printf(Locale.ROOT, "%s median_ms=%.3f p95_ms=%.3f allocated_B/op=%d%n",
+                name, times[count / 2] / 1_000_000.0,
+                times[Math.min(count - 1, (int) (count * .95))] / 1_000_000.0, allocated / count);
+    }
+
+    private static void menus(GameData data) throws Exception {
+        MenuScreen menu = new MenuScreen(data, "human", width, height, launch -> {});
+        menu.showMainMenu(data, Main.findMaps(data.source()));
+        attach(menu);
+        measure("menu", RenderBenchmark::paint);
+        menu.showMapsForTest(data, Main.findMaps(data.source()));
+        measure("map-menu", RenderBenchmark::paint);
+        try (GameLobby lobby = GameLobby.host("Benchmark", "ALAMO.PUD", 8, 0)) {
+            lobby.setOccupant(1, GameLobby.Occupant.COMPUTER);
+            attach(new LobbyScreen(data, lobby, "ALAMO.PUD", new LobbyScreen.Listener() {
+                public void onStart(GameLobby started) {}
+                public void onCancel() {}
+                public void onUpdateRequired() {}
+            }));
+            measure("lobby", RenderBenchmark::paint);
+        }
+        GameFont font = GameFont.load(data, GameFont.Face.GAME);
+        measure("font-width", () -> witness = font.widthOf("Lumber: 1200 Gold: 400"), 2000, 20000);
+        measure("font-fitted", () -> witness = font.fitted("A long multiplayer lobby name", 90).length(),
+                2000, 20000);
+    }
+
+    private record Scene(World world, GameScreen screen) {}
+
+    private static Scene scene(GameData data) {
+        String map = data.source().mapNames().stream().filter(name -> name.equalsIgnoreCase("ALAMO.PUD")
+                || name.toUpperCase(Locale.ROOT).endsWith("/ALAMO.PUD")).findFirst().orElseThrow();
+        PudMap pud = PudReader.read(data.source().map(map));
+        var tiles = data.loadTileset(pud.tileset());
+        World world = new World(GameMap.from(pud, tiles.tileset()), Player.forSoloGame(pud));
+        data.configureWorld(world, pud);
+        data.populate(world, pud);
+        world.recalculateSupply();
+        BattleShowcase.Result battle = battleUnits == 0 ? null
+                : BattleShowcase.deploy(world, data.unitTypes().types(), battleUnits);
+        var terrain = new MapRenderer(tiles.tileset(), tiles.sheet()).render(
+                world.map().width(), world.map().height(), world.map().tileCodes())
+                .toIndexedBufferedImage(tiles.palette());
+        SidePanel side = new SidePanel(world, data, 0, "human", "summer", data.uiLayout("human", 640, 480));
+        GameScreen screen = new GameScreen(world, data, terrain, tiles.palette(), "summer", 0,
+                width, height, null, side, null, null, null, tiles.cyclingRanges(), "human");
+        screen.setFogOpacity(data.fogOfWar().levels());
+        screen.setFogTiles(FogTiles.from(tiles.sheet(), data.fogOfWar().levels()));
+        int[] start = pud.startLocation(0);
+        if (battle != null) {
+            screen.centreOn(battle.centreX(), battle.centreY());
+            System.out.println("battle_units=" + battle.deployed());
+        } else if (start != null) {
+            screen.centreOn(start[0], start[1]);
+        }
+        return new Scene(world, screen);
+    }
+
+    private static void game(GameData data) {
+        Scene scene = scene(data);
+        attach(scene.screen());
+        for (int zoom : new int[] {1, 2}) {
+            scene.screen().setGameScale(zoom);
+            measure("game-zoom-" + zoom, RenderBenchmark::paint);
+            measure("game-palette-zoom-" + zoom, () -> {
+                scene.screen().cycleStep();
+                paint();
+            });
+        }
+        int[] movement = {0};
+        measure("game-camera-pan", () -> {
+            boolean right = movement[0]++ / 30 % 2 == 0;
+            scene.screen().keyDown(java.awt.event.KeyEvent.VK_RIGHT, right);
+            scene.screen().keyDown(java.awt.event.KeyEvent.VK_LEFT, !right);
+            scene.screen().scrollStep();
+            scene.screen().cycleStep();
+            paint();
+        });
+        scene.screen().keyDown(java.awt.event.KeyEvent.VK_RIGHT, false);
+        scene.screen().keyDown(java.awt.event.KeyEvent.VK_LEFT, false);
+        measure("game-tick-and-paint", () -> {
+            scene.world().tick();
+            scene.screen().cycleStep();
+            paint();
+        });
+        witness = SyncHash.of(scene.world());
+        System.out.printf(Locale.ROOT, "world_cycle=%d world_hash=%016x%n", scene.world().cycle(), witness);
+        BufferedImage reference = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = reference.createGraphics();
+        scene.screen().paint(g);
+        g.dispose();
+        java.util.zip.CRC32 pixels = new java.util.zip.CRC32();
+        for (int pixel : reference.getRGB(0, 0, width, height, null, 0, width)) {
+            for (int shift = 0; shift <= 24; shift += 8) {
+                pixels.update(pixel >> shift & 255);
+            }
+        }
+        System.out.printf(Locale.ROOT, "frame_crc32=%08x%n", pixels.getValue());
+    }
+
+    private static void stone() {
+        int[] next = {200};
+        measure("stone-resize", () -> {
+            BufferedImage image = StoneTexture.of(176, next[0]++, StoneTexture.Tint.STONE, 3);
+            witness = 1;
+            for (int y = 0; y < image.getHeight(); y += 7) {
+                for (int x = 0; x < image.getWidth(); x += 7) {
+                    witness = 31 * witness + image.getRGB(x, y);
+                }
+            }
+        }, 3, 24);
+    }
+
+    private static void soak(GameData data) throws Exception {
+        for (int session = 0; session < sessions; session++) {
+            SwingUtilities.invokeAndWait(() -> {
+                Scene scene = scene(data);
+                attach(scene.screen());
+                for (int cycle = 0; cycle < 120; cycle++) {
+                    scene.world().tick();
+                    scene.screen().cycleStep();
+                    if (cycle % 3 == 0) {
+                        scene.screen().centreOn(12 + cycle / 3, 12 + cycle / 4);
+                        paint();
+                    }
+                }
+                witness = SyncHash.of(scene.world());
+                attach(new JPanel());
+            });
+            // Each real transition returns to the event queue. Running thirty
+            // sessions inside one event callback instead retains all their
+            // pending resize/focus events and measures the blocked queue.
+            SwingUtilities.invokeAndWait(() -> {});
+            if ((session + 1) % 5 == 0) {
+                System.out.printf(Locale.ROOT, "sessions=%d heap_MiB=%d%n", session + 1,
+                        ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() / 1048576);
+            }
+        }
+    }
+}

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/TerrainViewTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/TerrainViewTest.java
@@ -1,0 +1,107 @@
+package net.chonkbase.chonkcraft.desktop;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.awt.image.IndexColorModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TerrainViewTest {
+    @Test
+    @DisplayName("terrain pieces join without seams while panning and zooming")
+    void piecesKeepTheOriginalPicture() {
+        BufferedImage ground = ground();
+        TerrainView view = new TerrainView();
+        for (double scale : new double[] {1, 1.25, 2, 3}) {
+            for (int x : new int[] {0, 1, 511, 512, 1000}) {
+                assertArrayEquals(pixels(reference(ground, x, 43, scale)),
+                        pixels(paint(view, ground, x, 43, scale)),
+                        "terrain seam at camera " + x + " and scale " + scale);
+            }
+        }
+        view.clear();
+    }
+
+    @Test
+    @DisplayName("cycling water keeps new colours and reuses a returning palette safely")
+    void palettePhasesKeepTheirColours() {
+        BufferedImage ground = ground();
+        TerrainView view = new TerrainView();
+        for (int alpha : new int[] {255, 128, 1, 0}) {
+            for (int colour : new int[] {0x2160C0, 0x4380E0, 0x2160C0}) {
+                int[] colours = {0xFF203020, alpha << 24 | colour, 0xFFB89050, 0xFF405030};
+                IndexColorModel palette = new IndexColorModel(8, colours.length, colours, 0, true, -1,
+                        java.awt.image.DataBuffer.TYPE_BYTE);
+                BufferedImage phase = new BufferedImage(palette, ground.getRaster(), false, null);
+                assertArrayEquals(pixels(reference(phase, 100, 30, 2)),
+                        pixels(paint(view, phase, 100, 30, 2)),
+                        "the visible water must use the current palette and alpha " + alpha);
+            }
+        }
+        view.clear();
+    }
+
+    @Test
+    @DisplayName("changed ground and returning to the map cannot resurrect old terrain")
+    void changedGroundInvalidatesEveryPicture() {
+        BufferedImage ground = ground();
+        TerrainView view = new TerrainView();
+        paint(view, ground, 450, 450, 2);
+        for (int y = 508; y < 533; y++) {
+            for (int x = 508; x < 533; x++) {
+                ground.getRaster().setSample(x, y, 0, 2);
+            }
+        }
+        view.invalidate(508, 508, 25, 25);
+        assertArrayEquals(pixels(reference(ground, 450, 450, 2)),
+                pixels(paint(view, ground, 450, 450, 2)), "changes crossing piece boundaries must be visible");
+        view.clear();
+        assertArrayEquals(pixels(reference(ground, 450, 450, 2)),
+                pixels(paint(view, ground, 450, 450, 2)), "returning after release must rebuild the current map");
+        view.clear();
+    }
+
+    private static BufferedImage ground() {
+        int[] colours = {0x203020, 0x2160C0, 0xB89050, 0x405030};
+        IndexColorModel palette = new IndexColorModel(8, colours.length, colours, 0, false, -1,
+                java.awt.image.DataBuffer.TYPE_BYTE);
+        BufferedImage image = new BufferedImage(1031, 789, BufferedImage.TYPE_BYTE_INDEXED, palette);
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                image.getRaster().setSample(x, y, 0, (x / 7 + y / 11) % 4);
+            }
+        }
+        return image;
+    }
+
+    private static BufferedImage reference(BufferedImage ground, int x, int y, double scale) {
+        BufferedImage result = new BufferedImage(400, 300, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = graphics(result, scale);
+        g.drawImage(ground, -x, -y, null);
+        g.dispose();
+        return result;
+    }
+
+    private static BufferedImage paint(TerrainView view, BufferedImage ground, int x, int y, double scale) {
+        BufferedImage result = new BufferedImage(400, 300, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = graphics(result, scale);
+        view.draw(g, ground, x, y, (int) Math.ceil(400 / scale), (int) Math.ceil(300 / scale));
+        g.dispose();
+        return result;
+    }
+
+    private static Graphics2D graphics(BufferedImage image, double scale) {
+        Graphics2D g = image.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+        g.scale(scale, scale);
+        return g;
+    }
+
+    private static int[] pixels(BufferedImage image) {
+        return image.getRGB(0, 0, image.getWidth(), image.getHeight(), null, 0, image.getWidth());
+    }
+}

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -358,6 +358,10 @@ rest. Java2D's software pipeline handles all of it headless. `MenuRenderSweepTes
 additionally writes PNGs to `desktop/target/menu-qa` as diagnostics for a human
 to look at; they are not what it asserts on.
 
+[Rendering performance](render-performance.md) documents the repeatable
+paint/allocation benchmark, display checks at 1x and 2x scale, and a bounded
+memory stress run. Software and device pipelines need separate measurements.
+
 Two places in main code guard the calls that genuinely throw without a display
 (`GameCursors` asking for a custom cursor size, `SidePanel` adding an
 `AWTEventListener`), so headless runs do not trip over them.
@@ -427,8 +431,9 @@ initialises, chosen by operating system:
 Override with `SEVEN_JAVA2D_PIPELINE=metal|opengl|xrender|d3d|software` or
 `-Dseven.java2d.pipeline=`. If the game renders wrongly or crashes in the
 driver on Linux, try `xrender` and then `software` before suspecting the port.
-**Verified by inspection** of `Java2DPipeline.defaultForOs`; the OpenGL default
-has not been exercised on Linux hardware.
+The defaults are verified by inspection of `Java2DPipeline.defaultForOs`.
+OpenGL rendering and memory stress have also been exercised on Linux/Asahi;
+see the [rendering measurements](render-performance.md).
 
 ### Fullscreen
 

--- a/docs/render-performance.md
+++ b/docs/render-performance.md
@@ -1,0 +1,190 @@
+# Rendering performance
+
+The renderer keeps the game's simulation cadence and rules intact. The work
+budget for a 144 Hz interface is 6.94 ms per paint. Static menus and waiting
+lobbies do not need continuous painting; input and changed information request
+new frames.
+
+## Measurements
+
+Measured on 2026-09-07 with an Apple M1 running Linux/Asahi, JBR
+25.0.2+10-b329.117 and the OpenGL pipeline. The host has 16 GiB of unified memory
+and a 60 Hz display. These are paint costs, including Java2D submission sync,
+not measured 144 Hz scanout or a claim about an actual 8 GiB macOS machine.
+
+The baseline is commit `c6a4402`. Both versions used the same owned Tides of
+Darkness pack, 40 warm-up paints and 180 measured paints per scene. The display
+processes used `-Xms64m -Xmx256m` inside a 2 GiB memory cgroup with no swap.
+Timing comparisons ran sequentially. The benchmark also reports allocations
+on the painting thread; that figure excludes driver memory and other threads.
+
+At 1280 by 800 logical pixels with 2x device scaling (2560 by 1600 backing
+pixels), all three menu samples meet the 6.94 ms budget at the 95th percentile:
+
+| Scene | Before median / p95, ms | After median / p95, ms | Before / after bytes per paint |
+|---|---:|---:|---:|
+| Main menu | 40.57 / 63.91 | 3.94 / 5.21 | 14,953,778 / 8,888 |
+| Map menu | 42.59 / 64.26 | 3.85 / 5.61 | 14,965,118 / 6,576 |
+| Lobby | 52.12 / 63.08 | 3.94 / 6.20 | 15,006,729 / 25,453 |
+
+The menu process's peak resident memory fell from 477 MiB to 235 MiB. Retained
+heap after collection was 21 MiB before and 16 MiB after. These measurements
+include the benchmark and the JVM, and exclude an audio session and the
+separate launcher.
+
+At 2560 by 1600 logical pixels and 1x device scaling, main-menu median paint
+time fell from 86.94 ms to 3.58 ms. The map menu and lobby fell from 86.22 and
+89.56 ms to 3.47 and 2.97 ms respectively. Their measured p95 values after the
+change were 6.11, 5.41 and 4.73 ms.
+
+Generating a growing stone panel at 3x scale fell from 71.42 ms median to
+0.54 ms in the headless resize probe. Its sampled pixel witness was identical
+before and after (`2879587974e9e69e`). Text measurement no longer constructs a
+scratch raster for each label: the width probe fell from about 1,370 bytes to
+32 bytes per call, and fitting a long name fell from about 3,170 to 820 bytes.
+
+## The memory failure
+
+The baseline did not finish the expanded display benchmark. Advancing the
+palette at zoom 1 exhausted its 2 GiB cgroup at 07:42:38 UTC. The kernel reported
+1,712,111,616 bytes of shmem and 1,679,687,680 unevictable bytes; the Java2D queue
+thread invoked the OOM killer, and the process printed an Asahi VM-bind failure.
+Its Java heap limit was only 256 MiB. A heap limit alone therefore did not bound
+this failure.
+
+The updated build completed that workload with a cgroup peak of about 455 MiB.
+A separate 2x-scale stress run constructed, painted, panned and retired 30
+matches, advancing each world 120 cycles. It completed with a nominal 256 MiB
+heap limit and a 1.5 GiB cgroup limit without swap. Peak resident memory was
+443 MiB, with a 609 MiB cgroup peak; retained heap after collection was 16 MiB.
+Event dispatch runs between transitions, as it does during play, so queued
+resize events do not artificially retain every retired screen.
+
+The old zoom-1 static terrain blit was already fast: 5.52 ms median versus
+4.48 ms with bounded terrain pieces in the final large-display run. The main
+benefit is bounded memory during palette cycling. The updated large-display
+game samples were about 4.5-5.6 ms median, with p95 values of 6.7-7.9 ms. This
+is not a claim that every gameplay frame fits a 144 Hz budget. Unit simulation
+and authored movie cadence are unchanged.
+
+A 400-unit battle at 1280 by 800 with 2x device scaling completed using a
+512 MiB heap. At zoom 2, median/p95 paint times were 4.42/6.25 ms; with palette
+animation they were 4.42/6.00 ms. A simulation tick plus paint took 11.31/21.21 ms,
+within the ordinary 30 Hz simulation budget. Cold palette phases at zoom 1
+and panning still produced p95 spikes around 34-54 ms. Peak resident memory was
+672 MiB and cgroup peak memory 842 MiB. Those cold-frame stalls remain an
+optimization opportunity, rather than a reason to increase cache limits
+without measuring the memory cost.
+
+The baseline and updated headless ALAMO runs both ended at cycle 220 with
+simulation hash `9e80782fd60587af` and frame CRC `bd7e794f`. The 400-unit battle
+retained its `6098ad31c2b3dfed` simulation hash and `c68f97a2` frame CRC across
+the terrain optimizations. The simulation sources were not changed.
+
+## What is bounded and reused
+
+- Menus and movies upload source pixels at one to one before scaling on the
+  device. Device scaling is accounted for so a Retina intermediate does not
+  consume four times its intended storage or change the sampling footprint.
+  Surface loss has bounded retries and a software fallback. Resize, device
+  changes and screen removal flush obsolete surfaces.
+- The indexed map stays in software. Terrain is cached as immutable 512-pixel
+  pieces, keyed by the palette colours each piece actually uses. Water does
+  not invalidate unrelated grass. Changed ground invalidates every retained
+  palette phase of the affected pieces.
+- Palette expansion uses a lookup table and bulk raster writes. A clipped
+  unscaled copy primes each new device image before its first transformed
+  draw, avoiding the managed-image cache's initial software path.
+- Terrain pictures have a 32 MiB raster budget, unit sprites 64 MiB, and stone
+  textures 32 MiB, with entry limits as well. Eviction flushes managed device
+  copies. These are raster budgets, not a total-process or total-VRAM limit.
+- Stone resizing copies the existing grain and computes only new rows and
+  columns. Generation uses one scratch row, not another full-size raster.
+- Font metrics and standard faces are reused. The minimap is updated in bulk.
+  Software fog uses reusable translucent tiles; device rendering retains the
+  faster native rectangle primitive.
+- Idle lobbies continue polling the network but repaint only changed display
+  state. The launcher progress animation follows elapsed time at the display
+  cadence, capped around 144 Hz, and stops when hidden. The game's starting
+  heap reservation is 64 MiB; its existing 2 GiB maximum remains available.
+
+## Reproduce
+
+Configure `CHONKCRAFT_ASSET_PACK` with a readable owned pack containing
+`ALAMO.PUD`, then build the application and benchmark classes:
+
+```sh
+scripts/jbr/with-jbr-25.sh mvn -pl desktop -am -DskipTests package
+```
+
+Run a software reference without opening a window:
+
+```sh
+scripts/jbr/with-jbr-25.sh java -Xms64m -Xmx256m \
+  -Djava.awt.headless=true \
+  -cp desktop/target/test-classes:desktop/target/chonkcraft-desktop-0.1.0-SNAPSHOT-app.jar \
+  net.chonkbase.chonkcraft.desktop.RenderBenchmark \
+  --mode=all --width=1280 --height=800
+```
+
+On Linux, isolate a display run with an OS memory limit. This is especially
+necessary when testing the baseline: `-Xmx` does not contain its reproduced
+graphics-memory growth.
+
+```sh
+systemd-run --user --scope -p MemoryMax=2G -p MemorySwapMax=0 \
+  scripts/jbr/with-jbr-25.sh java -Xms64m -Xmx256m \
+  -Dsun.java2d.opengl=True -Dsun.java2d.uiScale=2 \
+  -cp desktop/target/test-classes:desktop/target/chonkcraft-desktop-0.1.0-SNAPSHOT-app.jar \
+  net.chonkbase.chonkcraft.desktop.RenderBenchmark \
+  --display --mode=all --width=1280 --height=800
+```
+
+On macOS, use the same Java invocation with the normal Metal pipeline
+(`-Dsun.java2d.metal=true`) in place of the Linux OpenGL switch. A display run
+opens and resizes a temporary test window. Run one benchmark at a time.
+Modes are `menus`, `game`, `stone`, `soak`, and `all` (everything except the
+longer soak). `--frames`, `--warmup`, `--width`, `--height`, `--sessions` and
+`--battle` accept positive integers. `--battle=400 --mode=game` uses the game's
+ordinary battle showcase and command machinery. The probe does not open an
+audio device, save a game, record a session or connect to other players.
+
+For a transition stress run, use `--mode=soak --sessions=30`. For allocation
+stacks, add these JVM arguments before the class name:
+
+```sh
+-XX:FlightRecorderOptions=stackdepth=128 \
+-XX:StartFlightRecording=filename=target/render.jfr,settings=profile
+```
+
+Compare an older shaded application JAR by putting it after
+`desktop/target/test-classes` on the classpath. Keep the benchmark class,
+arguments, source pack, heap/OS limits, scale and pipeline identical. The game
+probe prints a simulation hash and a software frame CRC after the same number
+of ticks. The stone probe prints a sampled picture witness.
+
+`PixelScalerTest` and `TerrainViewTest` compare software pixels across scaling,
+panning, palette changes, terrain changes and cache release. The optional
+`PixelScalerDisplayCheck` compares the accelerated scaler with the original
+two-pass renderer on the same device, including resize and release/recreation:
+
+```sh
+scripts/jbr/with-jbr-25.sh java -Xmx256m \
+  -Dsun.java2d.opengl=True -Dsun.java2d.uiScale=2 \
+  -cp desktop/target/test-classes:desktop/target/chonkcraft-desktop-0.1.0-SNAPSHOT-app.jar \
+  net.chonkbase.chonkcraft.desktop.PixelScalerDisplayCheck
+```
+
+Forty changing frames passed at both 1x and 2x scaling. GPU interpolation
+varied from the software transform by at most 2 out of 255 per colour channel;
+geometry and image content agreed. Actual macOS Metal timing and 144 Hz
+scanout remain hardware validation work.
+
+The focused rendering and lifecycle run passed 76 tests with no skips, and
+all 49 launcher tests passed. The complete desktop run with the owned classic
+pack ran 370 tests with eight skips; its three failures exactly matched the
+existing expected-failure identities. The complete data-free reactor ran
+2,983 tests with 1,339 skips and the same 88 expected engine failures. Its
+failure-identity gate passed; the inherited engine skip-count mismatch remains
+(1,010 actual versus 989 recorded). No failure baselines were enlarged for this
+work. These runs do not substitute for the external BNE and Opus fixtures.

--- a/launcher/src/main/java/net/chonkbase/chonkcraft/launcher/ForgeProgressBar.java
+++ b/launcher/src/main/java/net/chonkbase/chonkcraft/launcher/ForgeProgressBar.java
@@ -23,11 +23,14 @@ import javax.swing.Timer;
 final class ForgeProgressBar extends JComponent {
 
     private int percent;
-    private int pulse;
+    private double pulse;
+    private long animationStarted;
     private boolean indeterminate = true;
     private boolean active;
-    private final Timer animation = new Timer(55, event -> {
-        pulse = (pulse + 1) % 120;
+    private final Timer animation = new Timer(7, event -> {
+        // Time, rather than repaint count, keeps the original 6.6 second
+        // sweep while allowing smooth motion on a high-refresh display.
+        pulse = ((System.nanoTime() - animationStarted) % 6_600_000_000L) / 55_000_000.0;
         if (isShowing()) {
             repaint();
         }
@@ -39,15 +42,31 @@ final class ForgeProgressBar extends JComponent {
         setMinimumSize(new Dimension(180, 29));
         setFont(LauncherTheme.BOLD.deriveFont(11f));
         setToolTipText("Graphics pack import progress");
+        addHierarchyListener(event -> {
+            if ((event.getChangeFlags() & java.awt.event.HierarchyEvent.SHOWING_CHANGED) != 0) {
+                updateAnimation();
+            }
+        });
+    }
+
+    private void updateAnimation() {
+        if (active && isShowing()) {
+            if (!animation.isRunning()) {
+                animationStarted = System.nanoTime() - (long) (pulse * 55_000_000.0);
+                int refresh = getGraphicsConfiguration().getDevice().getDisplayMode().getRefreshRate();
+                animation.setDelay(Math.max(7, 1000 / Math.max(60, refresh)));
+                animation.start();
+            }
+        } else {
+            animation.stop();
+        }
     }
 
     void begin() {
         percent = 0;
         indeterminate = true;
         active = true;
-        if (isShowing()) {
-            animation.start();
-        }
+        updateAnimation();
         repaint();
     }
 
@@ -55,9 +74,7 @@ final class ForgeProgressBar extends JComponent {
         percent = Math.max(0, Math.min(100, value));
         indeterminate = false;
         active = true;
-        if (isShowing()) {
-            animation.start();
-        }
+        updateAnimation();
         setToolTipText(percent + " percent complete");
         repaint();
     }
@@ -76,9 +93,7 @@ final class ForgeProgressBar extends JComponent {
     @Override
     public void addNotify() {
         super.addNotify();
-        if (active) {
-            animation.start();
-        }
+        updateAnimation();
     }
 
     @Override
@@ -118,7 +133,7 @@ final class ForgeProgressBar extends JComponent {
         int fillStart = x;
         if (indeterminate) {
             fill = Math.max(36, innerWidth / 4);
-            fillStart = x + (pulse * Math.max(1, innerWidth + fill) / 120) - fill;
+            fillStart = x + (int) (pulse * Math.max(1, innerWidth + fill) / 120) - fill;
         } else {
             fill = (int) Math.round(innerWidth * percent / 100.0);
         }
@@ -148,7 +163,7 @@ final class ForgeProgressBar extends JComponent {
             }
 
             int edge = Math.min(x + innerWidth - 2, fillStart + fill - 1);
-            int glint = 72 + (pulse % 20) * 7;
+            int glint = 72 + (int) ((pulse % 20) * 7);
             g.setColor(new Color(255, 246, 190, Math.min(210, glint)));
             g.fillOval(edge - 4, y + 2, 8, Math.max(3, innerHeight - 4));
             g.setClip(oldClip);

--- a/launcher/src/main/java/net/chonkbase/chonkcraft/launcher/GameReleaseManager.java
+++ b/launcher/src/main/java/net/chonkbase/chonkcraft/launcher/GameReleaseManager.java
@@ -347,7 +347,8 @@ public final class GameReleaseManager {
                 isWindows() ? "java.exe" : "java");
         List<String> command = new ArrayList<>();
         command.add(java.toString());
-        command.add("-Xms256m");
+        // Small menus should not commit a quarter gigabyte before a match loads.
+        command.add("-Xms64m");
         command.add("-Xmx2048m");
         // The child identifies the exact verified game JAR it is executing,
         // not the launcher's independently packaged version. Multiplayer

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -192,7 +192,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # The sealed-null-target and explicit-unit-target physical transaction
         # referees need the Human 1 retail mission and add two deliberate
         # data-free skips.
-        "desktop": (359, 270),
+        "desktop": (370, 270),
         "matchmaker-server": (5, 1),
     },
     # Everything configured. What a developer with the game data should see on
@@ -238,7 +238,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "engine": (2034, 7),
         # The classic hosted pack cannot run the explicit three-BNE-map
         # recording matrix, so that proof is a deliberate additional skip.
-        "desktop": (359, 8),
+        "desktop": (370, 8),
         "matchmaker-server": (5, 1),
     },
     # The same authenticated inputs as `full`, on a development machine that
@@ -253,7 +253,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "launcher": (49, 0),
         "matchmaking": (2, 0),
         "engine": (2034, 4),
-        "desktop": (359, 8),
+        "desktop": (370, 8),
         "matchmaker-server": (5, 1),
     },
     # The exact authenticated Battle.net Edition source archive, its matching
@@ -275,7 +275,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "launcher": (49, 0),
         "matchmaking": (2, 0),
         "engine": (2039, 12),
-        "desktop": (359, 6),
+        "desktop": (370, 6),
         "matchmaker-server": (5, 1),
     },
 }


### PR DESCRIPTION
An animated indexed map made new wrappers over the same small heap raster, but each wrapper could retain a full-map device texture. The baseline died inside a 2 GiB cgroup with 1.7 GB of shmem despite a 256 MiB heap limit. This survived heap-oriented checks because graphics memory did not cause enough Java allocation to trigger collection.

Keep full-map palettes in software and cache immutable 512-pixel terrain pieces by their used colours. Bound terrain, sprite and stone caches by bytes and entries, flush evicted device copies, and release screen-owned surfaces at transitions. Bulk palette expansion and a clipped first copy avoid the cold transformed-image software path. Changed ground invalidates all retained palette phases of its pieces.

Upload menu and movie art before scaling on the device, account for Retina backing scale, and retain bounded surface-loss retries with software fallback. Reuse font metrics, minimap pixels and stone grain. Poll idle lobbies without repainting unchanged state. Animate launcher progress by elapsed time and stop its timer when hidden; start the game with a 64 MiB heap reservation.

Retail rules and the 30 Hz simulation cadence stay intact. ALAMO finishes at cycle 220 with the same 9e80782fd60587af simulation hash and bd7e794f reference-frame CRC. The final previously-fatal display workload peaks at 455 MiB; thirty match transitions finish under a nominal 256 MiB heap cap. Retina menu p95 paint costs fall from 63-64 ms to 5.2-6.2 ms. Larger battles still have cold-frame stalls; macOS Metal and 144 Hz scanout need hardware validation. Retain repeatable measurement tools and conditions in the docs.

Validation: 76 focused desktop tests and all 49 launcher tests pass without skips. All 370 desktop tests with classic assets have eight skips and exactly the three pre-existing expected failures. The full data-free reactor runs 2,983 tests with 1,339 skips and exactly 88 expected engine failures; its failure-identity gate passes. The inherited engine skip-count mismatch (1,010 versus 989) remains, with failure baselines unchanged. All new tests are data-free, raising the desktop floor by eleven without adding skips. Accelerated scaling matches the original renderer within two channel values over forty changing frames, including movies, at both 1x and 2x. Packaging, source boundary, native runtime, comment provenance, documentation and BNE readiness checks pass.