### PR TITLE
Everyone plays at the speed the host picked, and a desync says where it went wrong

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -41,7 +41,7 @@ The current evidence and reproduction workflow are in
 
 All 18 playability lanes pass with their required authenticated inputs,
 including the 17-test control gate, 117 movement checks, 65 projectile
-checks, 39 clean/adverse lockstep cases and real two-process startup.
+checks, 41 clean/adverse lockstep cases and real two-process startup.
 The original 392-sequence freeze reproduction and the 45-type,
 11,340-sequence roster complete without a stuck final withdrawal.
 The 168 roster sequences containing invalid submarine-versus-land attacks
@@ -49,9 +49,9 @@ retain their explicit rejection classification; their final Move is still
 checked. Each submarine also passes 252 sequences against legal naval targets.
 These liveness sweeps are separate from exact native parity.
 
-The integrated pack-plus-Opus suite contains 3,012 tests, with 93 existing
+The integrated pack-plus-Opus suite contains 3,017 tests, with 93 existing
 specification failures, no errors and 322 skips. Its data-free counterpart
-has the same 88 expected failure identities and exactly 1,363 skips.
+has the same 88 expected failure identities and exactly 1,364 skips.
 Expected failures still execute; an inventory pass is not an all-tests-pass
 claim. The canonical authenticated CI job supplies the matching raw media
 and requires its separate 27-skip profile. Coverage rules are documented in

--- a/STATUS.md
+++ b/STATUS.md
@@ -41,7 +41,7 @@ The current evidence and reproduction workflow are in
 
 All 18 playability lanes pass with their required authenticated inputs,
 including the 17-test control gate, 117 movement checks, 65 projectile
-checks, 41 clean/adverse lockstep cases and real two-process startup.
+checks, 42 clean/adverse lockstep cases and real two-process startup.
 The original 392-sequence freeze reproduction and the 45-type,
 11,340-sequence roster complete without a stuck final withdrawal.
 The 168 roster sequences containing invalid submarine-versus-land attacks
@@ -49,9 +49,9 @@ retain their explicit rejection classification; their final Move is still
 checked. Each submarine also passes 252 sequences against legal naval targets.
 These liveness sweeps are separate from exact native parity.
 
-The integrated pack-plus-Opus suite contains 3,017 tests, with 93 existing
+The integrated pack-plus-Opus suite contains 3,020 tests, with 93 existing
 specification failures, no errors and 322 skips. Its data-free counterpart
-has the same 88 expected failure identities and exactly 1,364 skips.
+has the same 88 expected failure identities and exactly 1,366 skips.
 Expected failures still execute; an inventory pass is not an all-tests-pass
 claim. The canonical authenticated CI job supplies the matching raw media
 and requires its separate 27-skip profile. Coverage rules are documented in

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameMenu.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameMenu.java
@@ -178,6 +178,11 @@ final class GameMenu {
      */
     private List<String> lines = List.of();
 
+    /** What the page is saying in prose, for the tests that read it. */
+    List<String> linesForTest() {
+        return List.copyOf(lines);
+    }
+
     private String heading = "";
 
     /** Where each item was last drawn, in screen coordinates. */
@@ -216,6 +221,19 @@ final class GameMenu {
         int speed();
 
         void setSpeed(int cyclesPerSecond);
+
+        /**
+         * The name of the tempo this match is fixed at, or null when the
+         * player may choose their own.
+         *
+         * <p>Set for a network game, where the speed is part of what the
+         * lobby agreed and belongs to the table rather than to one player.
+         * The page says which setting is in force instead of offering a
+         * slider that would move nothing.
+         */
+        default String fixedSpeedCaption() {
+            return null;
+        }
 
         /** How much bigger than its design size the interface is drawn. */
         double interfaceScale();
@@ -417,6 +435,16 @@ final class GameMenu {
         heading = "Game Speed";
         clearWidgets();
         lines = List.of();
+        String fixed = session.fixedSpeedCaption();
+        if (fixed != null) {
+            // A slider that cannot move is worse than no slider: it says the
+            // player has a choice and then refuses it. Say who made the
+            // choice and what it was instead.
+            lines = List.of("The host set this match to " + fixed + ".",
+                    "Every player runs at the same speed.");
+            addReturn("Previous (Esc)", this::showOptions);
+            return;
+        }
         addSlider("Speed", 0,
                 () -> (session.speed() - SLOWEST) / (double) (FASTEST - SLOWEST),
                 fraction -> session.setSpeed(

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
@@ -4228,6 +4228,15 @@ final class GameScreen extends JPanel {
         if (session == null) {
             return;
         }
+        // The table plays at the speed its host chose, the way it cannot be
+        // paused by one player either. Saying so beats a key that silently
+        // does nothing.
+        String fixed = session.fixedSpeedCaption();
+        if (fixed != null) {
+            status = "The host set this match to " + fixed + ".";
+            repaint();
+            return;
+        }
         int wanted = Math.max(1, session.speed() + by);
         session.setSpeed(wanted);
         status = by > 0 ? "Faster." : "Slower.";

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/GameScreen.java
@@ -4229,11 +4229,15 @@ final class GameScreen extends JPanel {
             return;
         }
         // The table plays at the speed its host chose, the way it cannot be
-        // paused by one player either. Saying so beats a key that silently
-        // does nothing.
-        String fixed = session.fixedSpeedCaption();
-        if (fixed != null) {
-            status = "The host set this match to " + fixed + ".";
+        // paused by one player either. Asked of isNetworked rather than of
+        // the caption: the caption has a default that answers null, so a
+        // session that forgot to override it would quietly hand one player
+        // the speed of everybody else's game back.
+        if (session.isNetworked()) {
+            String fixed = session.fixedSpeedCaption();
+            status = fixed == null
+                    ? "The host sets the speed of a network game."
+                    : "The host set this match to " + fixed + ".";
             repaint();
             return;
         }

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
@@ -316,7 +316,6 @@ final class LobbyScreen extends JPanel {
     private void cycleGameSpeed() {
         GameLobby.GameSpeed current = lobby.state().gameSpeed();
         lobby.setGameSpeed(current.next());
-        notice = "";
     }
 
     /** Advances one player's explicit team without changing colour or start. */
@@ -623,6 +622,11 @@ final class LobbyScreen extends JPanel {
         return new Point(
                 (int) ((screen.x - fitted.x) * (double) DESIGN_WIDTH / fitted.width),
                 (int) ((screen.y - fitted.y) * (double) DESIGN_HEIGHT / fitted.height));
+    }
+
+    /** The face the footer's captions are drawn in, so a test can measure them. */
+    GameFont gameFaceForTest() {
+        return font;
     }
 
     /** The families this screen letters with, so a test can prove they match. */

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbyScreen.java
@@ -305,6 +305,20 @@ final class LobbyScreen extends JPanel {
         lobby.setGameTemplate(current.next());
     }
 
+    /**
+     * Cycles the tempo the whole table will play at.
+     *
+     * <p>Here rather than in the game because a network match runs at one
+     * speed or none: lockstep holds every machine at a net cycle boundary
+     * until the slowest has reported, so a player who slowed their own client
+     * slowed everybody's game by the same amount.
+     */
+    private void cycleGameSpeed() {
+        GameLobby.GameSpeed current = lobby.state().gameSpeed();
+        lobby.setGameSpeed(current.next());
+        notice = "";
+    }
+
     /** Advances one player's explicit team without changing colour or start. */
     private void cycleTeam(GameLobby.Slot slot) {
         int teamCount = Math.min(8, Math.max(2, lobby.capacity()));
@@ -531,17 +545,21 @@ final class LobbyScreen extends JPanel {
                     || state.hasValidMatchup()
                     || state.canInferComputerOpponents();
             boolean canStart = !starting && state.canStart();
-            button(g2, TABLE_X, FOOT_Y, 160, FOOT_HEIGHT,
+            button(g2, startBounds(),
                     starting ? "Starting..."
                             : !enoughPlayers ? "Waiting for Players"
                             : !opposingTeams ? "Assign Opponents"
                             : state.allPlayersReady() ? "Start Game" : "Syncing Map...",
                     canStart ? this::begin : null);
         }
-        button(g2, TABLE_X + 180, FOOT_Y, 200, FOOT_HEIGHT,
-                "Mode: " + state.gameTemplate().caption(),
+        button(g2, templateBounds(), "Mode: " + state.gameTemplate().caption(),
                 lobby.isHost() ? this::cycleGameTemplate : null);
-        button(g2, TABLE_X + TABLE_WIDTH - 160, FOOT_Y, 160, FOOT_HEIGHT,
+        // Shown to everybody and clickable only by the host, like Mode. A
+        // joiner who cannot see the speed cannot tell a match that is meant
+        // to be slow from one whose host has a struggling machine.
+        button(g2, speedBounds(), "Speed: " + state.gameSpeed().caption(),
+                lobby.isHost() ? this::cycleGameSpeed : null);
+        button(g2, cancelBounds(),
                 state.updateRequired() ? "Quit to Update" : "Cancel (Esc)",
                 state.updateRequired() ? this::quitForUpdate : this::cancel);
     }
@@ -579,6 +597,10 @@ final class LobbyScreen extends JPanel {
     }
 
     /** Draws a button and, when it does something, registers where it is. */
+    private void button(Graphics2D g2, Rectangle where, String caption, Runnable action) {
+        button(g2, where.x, where.y, where.width, where.height, caption, action);
+    }
+
     private void button(Graphics2D g2, int x, int y, int width, int height,
             String caption, Runnable action) {
         PanelArt.panel(g2, x, y, width, height,
@@ -641,19 +663,32 @@ final class LobbyScreen extends JPanel {
                 84, ROW_HEIGHT - 8);
     }
 
-    /** Where the Start button is. */
+    /**
+     * Where the Start button is.
+     *
+     * <p>The four footer controls are measured against their own longest
+     * caption in the game face rather than shared out evenly: "Waiting for
+     * Players" is 120 pixels wide and "Speed: Slowest" is 91, so an even
+     * quarter each would have left the first one overflowing its panel while
+     * the others sat half empty.
+     */
     static Rectangle startBounds() {
-        return new Rectangle(TABLE_X, FOOT_Y, 160, FOOT_HEIGHT);
+        return new Rectangle(TABLE_X, FOOT_Y, 150, FOOT_HEIGHT);
     }
 
     /** Where the synchronized game-template control is drawn. */
     static Rectangle templateBounds() {
-        return new Rectangle(TABLE_X + 180, FOOT_Y, 200, FOOT_HEIGHT);
+        return new Rectangle(TABLE_X + 160, FOOT_Y, 110, FOOT_HEIGHT);
+    }
+
+    /** Where the synchronized game-speed control is drawn. */
+    static Rectangle speedBounds() {
+        return new Rectangle(TABLE_X + 280, FOOT_Y, 130, FOOT_HEIGHT);
     }
 
     /** Where Cancel, or the build-mismatch update action, is drawn. */
     static Rectangle cancelBounds() {
-        return new Rectangle(TABLE_X + TABLE_WIDTH - 160, FOOT_Y, 160, FOOT_HEIGHT);
+        return new Rectangle(TABLE_X + TABLE_WIDTH - 140, FOOT_Y, 140, FOOT_HEIGHT);
     }
 
     /** Drives one click at a point in design pixels, for tests. */

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbySetup.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbySetup.java
@@ -144,6 +144,7 @@ record LobbySetup(Path map, GameLobby lobby) {
             }
         }
         game.setPlayerNames(names);
+        game.setCyclesPerSecond(state.gameSpeed().cyclesPerSecond());
         game.start();
         return new Started(game, world, applier);
     }

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbySetup.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/LobbySetup.java
@@ -144,7 +144,7 @@ record LobbySetup(Path map, GameLobby lobby) {
             }
         }
         game.setPlayerNames(names);
-        game.setCyclesPerSecond(state.gameSpeed().cyclesPerSecond());
+        game.setGameSpeed(state.gameSpeed());
         game.start();
         return new Started(game, world, applier);
     }

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/Main.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/Main.java
@@ -1712,6 +1712,7 @@ public final class Main {
             try {
                 PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
                         world, savePath, synchronizedMapBytes, localPlayer,
+                        network.cyclesPerSecond(),
                         network.scheduler().cyclesPerUpdate(), network.scheduler().lag(),
                         MatchmakingProtocol.gameBuild());
                 network.setCycleSink(recorder);
@@ -2088,7 +2089,11 @@ public final class Main {
                 new java.util.concurrent.atomic.AtomicBoolean();
 
         // The simulation runs at its own fixed rate, independent of repaint.
-        FixedStepLoop loop = new FixedStepLoop("chonkcraft-sim", World.CYCLES_PER_SECOND);
+        // A network game opens at the tempo the lobby agreed, so every
+        // machine at the table starts at the same one; a solo game opens at
+        // the rate the simulation counts in.
+        FixedStepLoop loop = new FixedStepLoop("chonkcraft-sim",
+                network == null ? World.CYCLES_PER_SECOND : network.cyclesPerSecond());
 
         /*
          * Everything this game holds, given up in one place.
@@ -2162,7 +2167,22 @@ public final class Main {
 
             @Override
             public void setSpeed(int cyclesPerSecond) {
+                // Refused in a network game for the same reason Pause is:
+                // the table plays at one tempo, agreed in the lobby. A player
+                // who slowed only their own client held every other machine
+                // at the next net cycle boundary until it caught up, so the
+                // whole match ran at whatever the slowest slider was set to.
+                if (network != null) {
+                    return;
+                }
                 loop.setHertz(Math.max(1, cyclesPerSecond));
+            }
+
+            @Override
+            public String fixedSpeedCaption() {
+                return network == null ? null
+                        : net.chonkbase.chonkcraft.engine.network.GameLobby.GameSpeed
+                                .of(network.cyclesPerSecond()).caption();
             }
 
             @Override
@@ -2320,8 +2340,16 @@ public final class Main {
                         networkNoticeUntil[0] = System.currentTimeMillis() + 5_000L;
                     }
                     if (step == net.chonkbase.chonkcraft.engine.network.NetworkGame.Step.DESYNC) {
-                        screen.setStatus("desynchronised at cycle " + network.desyncCycle()
-                                + " with player " + network.desyncPlayer());
+                        // Named the way every other network message names a
+                        // player. This used to print the raw slot index, so
+                        // the message about player 2 called them player 1 and
+                        // a report of it could not be matched to anybody. The
+                        // flight record that goes with it was named on stdout
+                        // when the match opened; the status line is one line
+                        // and a path would be cut off in a small window.
+                        screen.setStatus("desynchronised at cycle "
+                                + network.desyncCycle() + " with "
+                                + network.nameOfPlayer(network.desyncPlayer()));
                     } else if (step == net.chonkbase.chonkcraft.engine.network.NetworkGame
                             .Step.HOST_LEFT) {
                         if (System.currentTimeMillis() >= networkNoticeUntil[0]) {

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/Main.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/Main.java
@@ -1712,8 +1712,9 @@ public final class Main {
             try {
                 PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
                         world, savePath, synchronizedMapBytes, localPlayer,
-                        network.cyclesPerSecond(),
-                        network.scheduler().cyclesPerUpdate(), network.scheduler().lag(),
+                        new PassiveMultiplayerRecorder.Pacing(network.cyclesPerSecond(),
+                                network.scheduler().cyclesPerUpdate(),
+                                network.scheduler().lag()),
                         MatchmakingProtocol.gameBuild());
                 network.setCycleSink(recorder);
                 System.out.println("Multiplayer recording: " + recorder.directory());
@@ -2180,9 +2181,7 @@ public final class Main {
 
             @Override
             public String fixedSpeedCaption() {
-                return network == null ? null
-                        : net.chonkbase.chonkcraft.engine.network.GameLobby.GameSpeed
-                                .of(network.cyclesPerSecond()).caption();
+                return network == null ? null : network.gameSpeed().caption();
             }
 
             @Override
@@ -2347,9 +2346,10 @@ public final class Main {
                         // flight record that goes with it was named on stdout
                         // when the match opened; the status line is one line
                         // and a path would be cut off in a small window.
-                        screen.setStatus("desynchronised at cycle "
-                                + network.desyncCycle() + " with "
-                                + network.nameOfPlayer(network.desyncPlayer()));
+                        screen.setStatus("desynchronised at net cycle "
+                                + network.desyncCycle() + ", game cycle "
+                                + network.desyncWorldCycle() + ", with "
+                                + network.playerName(network.desyncPlayer()));
                     } else if (step == net.chonkbase.chonkcraft.engine.network.NetworkGame
                             .Step.HOST_LEFT) {
                         if (System.currentTimeMillis() >= networkNoticeUntil[0]) {

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/NetworkPeer.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/NetworkPeer.java
@@ -98,8 +98,7 @@ public final class NetworkPeer {
                 case "--game-template" -> gameTemplate = "teams".equalsIgnoreCase(
                         args[i + 1]) ? GameLobby.GameTemplate.TEAMS
                                 : GameLobby.GameTemplate.MELEE;
-                case "--game-speed" -> gameSpeed = GameLobby.GameSpeed.valueOf(
-                        args[i + 1].toUpperCase(java.util.Locale.ROOT));
+                case "--game-speed" -> gameSpeed = speedNamed(args[i + 1]);
                 default -> { }
             }
         }
@@ -217,9 +216,7 @@ public final class NetworkPeer {
             // client that printed the host's choice heard it over the wire
             // rather than defaulting to its own.
             System.out.printf("peer %d game speed: %s %d cycles a second%n",
-                    localPlayer,
-                    GameLobby.GameSpeed.of(game.cyclesPerSecond()).caption(),
-                    game.cyclesPerSecond());
+                    localPlayer, game.gameSpeed().caption(), game.cyclesPerSecond());
         } else {
             List<UnitType> roster = new ArrayList<>(data.unitTypes().types().values());
             CommandApplier applier = new CommandApplier(world, roster);
@@ -476,6 +473,29 @@ public final class NetworkPeer {
                 lobby.state().gameTemplate());
         return new LobbyRun(lobby, lobby.state().localSlot(), lobby.state().map(),
                 lobby.mapBytes());
+    }
+
+    /**
+     * The speed a flag names, or a complaint that names the choices.
+     *
+     * <p>An unrecognised value used to come out of {@code valueOf} as a bare
+     * IllegalArgumentException before the peer had bound anything, so the
+     * network gate reported a dead host and a stack trace rather than the
+     * typo that caused it.
+     */
+    private static GameLobby.GameSpeed speedNamed(String value) {
+        for (GameLobby.GameSpeed speed : GameLobby.GameSpeed.values()) {
+            if (speed.name().equalsIgnoreCase(value)) {
+                return speed;
+            }
+        }
+        StringBuilder known = new StringBuilder();
+        for (GameLobby.GameSpeed speed : GameLobby.GameSpeed.values()) {
+            known.append(known.isEmpty() ? "" : ", ").append(speed.caption().toLowerCase(
+                    java.util.Locale.ROOT));
+        }
+        throw new IllegalArgumentException("--game-speed " + value
+                + " is not a speed; choose one of " + known);
     }
 
     private static void settleAndStart(GameLobby lobby, boolean computerPlayer,

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/NetworkPeer.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/NetworkPeer.java
@@ -79,6 +79,7 @@ public final class NetworkPeer {
         boolean withoutMap = false;
         boolean computerPlayer = false;
         GameLobby.GameTemplate gameTemplate = GameLobby.GameTemplate.MELEE;
+        GameLobby.GameSpeed gameSpeed = GameLobby.GameSpeed.NORMAL;
 
         for (int i = 0; i + 1 < args.length; i += 2) {
             switch (args[i]) {
@@ -97,6 +98,8 @@ public final class NetworkPeer {
                 case "--game-template" -> gameTemplate = "teams".equalsIgnoreCase(
                         args[i + 1]) ? GameLobby.GameTemplate.TEAMS
                                 : GameLobby.GameTemplate.MELEE;
+                case "--game-speed" -> gameSpeed = GameLobby.GameSpeed.valueOf(
+                        args[i + 1].toUpperCase(java.util.Locale.ROOT));
                 default -> { }
             }
         }
@@ -136,13 +139,14 @@ public final class NetworkPeer {
         if (onlineHost != null || onlineJoin != null) {
             URI service = URI.create(onlineHost != null ? onlineHost : matchmakerUrl);
             lobbyRun = meetOnline(assets, mapName, selectedMap, service,
-                    onlineJoin, withoutMap, computerPlayer, gameTemplate);
+                    onlineJoin, withoutMap, computerPlayer, gameTemplate, gameSpeed);
             localPlayer = lobbyRun.localPlayer();
             mapName = lobbyRun.mapName();
             selectedMap = lobbyRun.mapBytes();
         } else if (lobbyHost != null || lobbyJoin != null) {
             lobbyRun = meetInLobby(assets, mapName, selectedMap,
-                    lobbyHost, lobbyJoin, withoutMap, computerPlayer, gameTemplate);
+                    lobbyHost, lobbyJoin, withoutMap, computerPlayer, gameTemplate,
+                    gameSpeed);
             localPlayer = lobbyRun.localPlayer();
             mapName = lobbyRun.mapName();
             selectedMap = lobbyRun.mapBytes();
@@ -208,6 +212,14 @@ public final class NetworkPeer {
             listeningPort = lobbyRun.lobby().localPort();
             peerCount = lobbyRun.lobby().peers().size();
             game = lobbySetup.start(data, world).game();
+            // The tempo the lobby settled, read back off the running game.
+            // This is the seam the desktop uses to open its loop, and a
+            // client that printed the host's choice heard it over the wire
+            // rather than defaulting to its own.
+            System.out.printf("peer %d game speed: %s %d cycles a second%n",
+                    localPlayer,
+                    GameLobby.GameSpeed.of(game.cyclesPerSecond()).caption(),
+                    game.cyclesPerSecond());
         } else {
             List<UnitType> roster = new ArrayList<>(data.unitTypes().types().values());
             CommandApplier applier = new CommandApplier(world, roster);
@@ -363,7 +375,8 @@ public final class NetworkPeer {
     /** Meets another process through the same public HTTPS/WSS path as the desktop menus. */
     private static LobbyRun meetOnline(AssetSource assets, String mapName, byte[] selectedMap,
             URI service, String joinCode, boolean withoutMap,
-            boolean computerPlayer, GameLobby.GameTemplate gameTemplate) throws Exception {
+            boolean computerPlayer, GameLobby.GameTemplate gameTemplate,
+            GameLobby.GameSpeed gameSpeed) throws Exception {
         boolean hosting = joinCode == null;
         MatchmakingClient client = new MatchmakingClient(service);
         MatchmakingProtocol.Seat seat;
@@ -401,7 +414,7 @@ public final class NetworkPeer {
         while (System.currentTimeMillis() < deadline && !lobby.isStarted()) {
             lobby.poll();
             if (hosting && lobby.humanCount() >= 2 && lobby.state().allPlayersReady()) {
-                settleAndStart(lobby, computerPlayer, gameTemplate);
+                settleAndStart(lobby, computerPlayer, gameTemplate, gameSpeed);
                 relay.markRoomStarted();
                 lobby.start();
             }
@@ -422,7 +435,8 @@ public final class NetworkPeer {
     /** Meets one other process, synchronizes the map, and leaves the socket ready for play. */
     private static LobbyRun meetInLobby(AssetSource assets, String mapName, byte[] selectedMap,
             String hostPort, String joinAddress, boolean withoutMap,
-            boolean computerPlayer, GameLobby.GameTemplate gameTemplate) throws Exception {
+            boolean computerPlayer, GameLobby.GameTemplate gameTemplate,
+            GameLobby.GameSpeed gameSpeed) throws Exception {
         boolean hosting = hostPort != null;
         GameLobby lobby;
         if (hosting) {
@@ -447,7 +461,7 @@ public final class NetworkPeer {
         while (System.currentTimeMillis() < deadline && !lobby.isStarted()) {
             lobby.poll();
             if (hosting && lobby.humanCount() >= 2 && lobby.state().allPlayersReady()) {
-                settleAndStart(lobby, computerPlayer, gameTemplate);
+                settleAndStart(lobby, computerPlayer, gameTemplate, gameSpeed);
                 lobby.start();
             }
             Thread.sleep(2);
@@ -465,8 +479,9 @@ public final class NetworkPeer {
     }
 
     private static void settleAndStart(GameLobby lobby, boolean computerPlayer,
-            GameLobby.GameTemplate gameTemplate) {
+            GameLobby.GameTemplate gameTemplate, GameLobby.GameSpeed gameSpeed) {
         lobby.setGameTemplate(gameTemplate);
+        lobby.setGameSpeed(gameSpeed);
         if (gameTemplate == GameLobby.GameTemplate.TEAMS) {
             // Exercise the common user setup directly: the two people begin
             // together, while the deliberately unsplit computer proves Start

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorder.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorder.java
@@ -75,6 +75,17 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
     /** The controller and race table the lobby actually installed. */
     private record RecordedPlayer(int index, String type, String race) {}
 
+    /**
+     * How the match was paced, carried as one value rather than three ints.
+     *
+     * <p>{@code cyclesPerSecond} and {@code cyclesPerUpdate} are both small
+     * numbers with almost the same name, and side by side in an argument list
+     * a caller can swap them and still compile. The record then claims five
+     * cycles a second and sixty cycles to a net cycle, which nothing checks
+     * and nobody notices until the figures it seals are read back.
+     */
+    record Pacing(int cyclesPerSecond, int cyclesPerUpdate, int lag) {}
+
     /** The exact installed game artifact, when this is an OTA-launched build. */
     record RuntimeIdentity(String gameJarSha256, Long gameJarBytes,
             String sourceRevision) {
@@ -138,9 +149,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
     private final String initialSaveHash;
     private final List<RecordedPlayer> players;
     private final int localPlayer;
-    private final int cyclesPerSecond;
-    private final int cyclesPerUpdate;
-    private final int lag;
+    private final Pacing pacing;
     private final Instant createdAt;
     private final long initialWorldCycle;
     private final long initialSyncHash;
@@ -162,7 +171,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
 
     private PassiveMultiplayerRecorder(Path root, Path directory, String mapName,
             String mapHash, long mapBytes, String build, int localPlayer,
-            int cyclesPerSecond, int cyclesPerUpdate, int lag, Instant createdAt, World world,
+            Pacing pacing, Instant createdAt, World world,
             long initialSaveBytes, String initialSaveHash, FileChannel activityChannel,
             FileLock activityLock) {
         this.root = root;
@@ -181,9 +190,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
         }
         players = List.copyOf(roster);
         this.localPlayer = localPlayer;
-        this.cyclesPerSecond = cyclesPerSecond;
-        this.cyclesPerUpdate = cyclesPerUpdate;
-        this.lag = lag;
+        this.pacing = pacing;
         this.createdAt = createdAt;
         initialWorldCycle = world.cycle();
         initialSyncHash = SyncHash.of(world);
@@ -212,15 +219,14 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
      *                        the six the simulation's own rate would suggest.
      */
     static PassiveMultiplayerRecorder open(World world, String mapName, byte[] mapBytes,
-            int localPlayer, int cyclesPerSecond, int cyclesPerUpdate, int lag, String build)
-            throws IOException {
-        return open(world, mapName, mapBytes, localPlayer, cyclesPerSecond, cyclesPerUpdate,
-                lag, build, defaultDirectory(), Instant.now());
+            int localPlayer, Pacing pacing, String build) throws IOException {
+        return open(world, mapName, mapBytes, localPlayer, pacing, build,
+                defaultDirectory(), Instant.now());
     }
 
     /** The same operation with a caller-owned directory and clock for tests. */
     static PassiveMultiplayerRecorder open(World world, String mapName, byte[] mapBytes,
-            int localPlayer, int cyclesPerSecond, int cyclesPerUpdate, int lag, String build,
+            int localPlayer, Pacing pacing, String build,
             Path root, Instant createdAt) throws IOException {
         if (world == null || mapBytes == null || mapBytes.length == 0) {
             throw new IllegalArgumentException("a recording needs a world and its map bytes");
@@ -242,7 +248,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
             SaveGame.write(world, mapName, null, 0, initialSave);
             PassiveMultiplayerRecorder recorder = new PassiveMultiplayerRecorder(
                     root, directory, mapName, sha256(mapBytes), mapBytes.length, build,
-                    localPlayer, cyclesPerSecond, cyclesPerUpdate, lag, createdAt, world,
+                    localPlayer, pacing, createdAt, world,
                     Files.size(initialSave), sha256(initialSave), channel, lock);
             recorder.writeManifest("recording", null, null, 0, 0, -1,
                     world.cycle(), SyncHash.of(world), 0, null);
@@ -429,9 +435,9 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
         }
         out.append("  ],\n");
         out.append("  \"local_player\": ").append(localPlayer).append(",\n");
-        out.append("  \"cycles_per_second\": ").append(cyclesPerSecond).append(",\n");
-        out.append("  \"cycles_per_update\": ").append(cyclesPerUpdate).append(",\n");
-        out.append("  \"lag\": ").append(lag).append(",\n");
+        out.append("  \"cycles_per_second\": ").append(pacing.cyclesPerSecond()).append(",\n");
+        out.append("  \"cycles_per_update\": ").append(pacing.cyclesPerUpdate()).append(",\n");
+        out.append("  \"lag\": ").append(pacing.lag()).append(",\n");
         out.append("  \"initial_world_cycle\": ").append(initialWorldCycle).append(",\n");
         field(out, "initial_sync_hash", hash(initialSyncHash), true);
         out.append("  \"initial_sync_rng\": {\"seed\": ").append(initialSyncSeed)

--- a/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorder.java
+++ b/desktop/src/main/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorder.java
@@ -138,6 +138,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
     private final String initialSaveHash;
     private final List<RecordedPlayer> players;
     private final int localPlayer;
+    private final int cyclesPerSecond;
     private final int cyclesPerUpdate;
     private final int lag;
     private final Instant createdAt;
@@ -161,7 +162,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
 
     private PassiveMultiplayerRecorder(Path root, Path directory, String mapName,
             String mapHash, long mapBytes, String build, int localPlayer,
-            int cyclesPerUpdate, int lag, Instant createdAt, World world,
+            int cyclesPerSecond, int cyclesPerUpdate, int lag, Instant createdAt, World world,
             long initialSaveBytes, String initialSaveHash, FileChannel activityChannel,
             FileLock activityLock) {
         this.root = root;
@@ -180,6 +181,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
         }
         players = List.copyOf(roster);
         this.localPlayer = localPlayer;
+        this.cyclesPerSecond = cyclesPerSecond;
         this.cyclesPerUpdate = cyclesPerUpdate;
         this.lag = lag;
         this.createdAt = createdAt;
@@ -200,17 +202,26 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
                 "chonkcraft-multiplayer-recorder-shutdown");
     }
 
-    /** Starts a recorder in the player's ordinary per-user recordings directory. */
+    /**
+     * Starts a recorder in the player's ordinary per-user recordings directory.
+     *
+     * @param cyclesPerSecond the tempo the lobby agreed, which is what turns a
+     *                        cycle count in this record back into the seconds
+     *                        the players actually spent. A match the host set
+     *                        to Fastest plays 180 cycles in three seconds, not
+     *                        the six the simulation's own rate would suggest.
+     */
     static PassiveMultiplayerRecorder open(World world, String mapName, byte[] mapBytes,
-            int localPlayer, int cyclesPerUpdate, int lag, String build) throws IOException {
-        return open(world, mapName, mapBytes, localPlayer, cyclesPerUpdate, lag, build,
-                defaultDirectory(), Instant.now());
+            int localPlayer, int cyclesPerSecond, int cyclesPerUpdate, int lag, String build)
+            throws IOException {
+        return open(world, mapName, mapBytes, localPlayer, cyclesPerSecond, cyclesPerUpdate,
+                lag, build, defaultDirectory(), Instant.now());
     }
 
     /** The same operation with a caller-owned directory and clock for tests. */
     static PassiveMultiplayerRecorder open(World world, String mapName, byte[] mapBytes,
-            int localPlayer, int cyclesPerUpdate, int lag, String build, Path root,
-            Instant createdAt) throws IOException {
+            int localPlayer, int cyclesPerSecond, int cyclesPerUpdate, int lag, String build,
+            Path root, Instant createdAt) throws IOException {
         if (world == null || mapBytes == null || mapBytes.length == 0) {
             throw new IllegalArgumentException("a recording needs a world and its map bytes");
         }
@@ -231,7 +242,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
             SaveGame.write(world, mapName, null, 0, initialSave);
             PassiveMultiplayerRecorder recorder = new PassiveMultiplayerRecorder(
                     root, directory, mapName, sha256(mapBytes), mapBytes.length, build,
-                    localPlayer, cyclesPerUpdate, lag, createdAt, world,
+                    localPlayer, cyclesPerSecond, cyclesPerUpdate, lag, createdAt, world,
                     Files.size(initialSave), sha256(initialSave), channel, lock);
             recorder.writeManifest("recording", null, null, 0, 0, -1,
                     world.cycle(), SyncHash.of(world), 0, null);
@@ -418,7 +429,7 @@ final class PassiveMultiplayerRecorder implements NetworkGame.CycleSink, AutoClo
         }
         out.append("  ],\n");
         out.append("  \"local_player\": ").append(localPlayer).append(",\n");
-        out.append("  \"cycles_per_second\": ").append(World.CYCLES_PER_SECOND).append(",\n");
+        out.append("  \"cycles_per_second\": ").append(cyclesPerSecond).append(",\n");
         out.append("  \"cycles_per_update\": ").append(cyclesPerUpdate).append(",\n");
         out.append("  \"lag\": ").append(lag).append(",\n");
         out.append("  \"initial_world_cycle\": ").append(initialWorldCycle).append(",\n");

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/GameMenuTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/GameMenuTest.java
@@ -53,6 +53,9 @@ class GameMenuTest {
         private boolean synthesised;
         private List<String> objectives = List.of();
 
+        /** Set when this session stands for a machine in a network game. */
+        private String fixedSpeed;
+
         @Override
         public void setPaused(boolean value) {
             paused = value;
@@ -144,7 +147,12 @@ class GameMenuTest {
 
         @Override
         public boolean isNetworked() {
-            return false;
+            return fixedSpeed != null;
+        }
+
+        @Override
+        public String fixedSpeedCaption() {
+            return fixedSpeed;
         }
 
         @Override
@@ -383,6 +391,35 @@ class GameMenuTest {
         assertEquals(5, session.speed(), "the slow end");
         menu.drag(left + 224, trackY);
         assertEquals(60, session.speed(), "the fast end");
+    }
+
+    @Test
+    @DisplayName("In a network game the speed page says what the host chose and offers no slider")
+    void aNetworkedMatchPlaysAtTheSpeedItsHostChose() {
+        GameData data = load();
+        Recording session = new Recording();
+        session.fixedSpeed = "Slower";
+        GameMenu menu = new GameMenu(data, "human", session);
+        menu.open();
+        render(menu);
+        clickRow(menu, 1);   // Options
+        render(menu);
+        clickRow(menu, 0);   // Game Speed
+        render(menu);
+
+        int left = panelLeft() + 16;
+        int trackY = panelTop() + 40 + 30 - 5;
+        menu.click(left, trackY);
+        menu.drag(left + 224, trackY);
+        assertEquals(30, session.speed(),
+                "one player dragged the whole table's speed about; lockstep holds every"
+                        + " machine at the next agreed cycle, so a client that slows itself"
+                        + " slows everybody else's game by the same amount");
+
+        // And it says so, rather than leaving a control that does nothing.
+        assertTrue(menu.linesForTest().stream()
+                        .anyMatch(line -> line.contains("Slower")),
+                "the page does not name the speed the host set: " + menu.linesForTest());
     }
 
     /**

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/HotkeyBindingTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/HotkeyBindingTest.java
@@ -58,6 +58,9 @@ class HotkeyBindingTest {
         private float effects = 0.8f;
         private float music = 0.6f;
         private boolean synthesised;
+
+        /** Set when this session stands for a machine in a network game. */
+        private String fixedSpeed;
         private final List<String> asked = new ArrayList<>();
 
         @Override
@@ -154,7 +157,12 @@ class HotkeyBindingTest {
 
         @Override
         public boolean isNetworked() {
-            return false;
+            return fixedSpeed != null;
+        }
+
+        @Override
+        public String fixedSpeedCaption() {
+            return fixedSpeed;
         }
 
         @Override
@@ -218,6 +226,38 @@ class HotkeyBindingTest {
                 | (alt ? InputEvent.ALT_DOWN_MASK : 0);
         screen.keyPressed(new KeyEvent(screen, KeyEvent.KEY_PRESSED,
                 System.currentTimeMillis(), mask, code, KeyEvent.CHAR_UNDEFINED));
+    }
+
+    @Test
+    @DisplayName("the speed keys move a solo game and are refused in a network game")
+    void theSpeedKeysBelongToTheHostInANetworkGame() {
+        Scene scene = scene();
+        GameScreen screen = scene.screen();
+        Recording session = scene.session();
+
+        // Alone, the keys are the player's own.
+        press(screen, KeyEvent.VK_EQUALS, false, false);
+        assertTrue(session.speed > 30,
+                "the speed key did not make a solo game any faster");
+        press(screen, KeyEvent.VK_MINUS, false, false);
+        press(screen, KeyEvent.VK_MINUS, false, false);
+        assertTrue(session.speed < 31,
+                "the speed key did not make a solo game any slower");
+
+        // At a table, they are not. A client that slows only itself slows
+        // everybody's game by the same amount, because lockstep holds every
+        // machine at the next agreed cycle until the slowest has reported.
+        session.fixedSpeed = "Slower";
+        int agreed = session.speed;
+        press(screen, KeyEvent.VK_EQUALS, false, false);
+        press(screen, KeyEvent.VK_ADD, false, false);
+        press(screen, KeyEvent.VK_MINUS, false, false);
+        press(screen, KeyEvent.VK_SUBTRACT, false, false);
+        assertEquals(agreed, session.speed,
+                "one player moved the whole table's speed with the keyboard");
+        assertTrue(screen.status().contains("Slower"),
+                "the refused key said nothing about who set the speed: "
+                        + screen.status());
     }
 
     @Test

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.List;
 import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.net.InetAddress;
@@ -192,6 +194,67 @@ class LobbyScreenTest {
             screen.render();
             assertTrue(click(screen, LobbyScreen.templateBounds()));
             assertEquals(GameLobby.GameTemplate.MELEE, lobby.state().gameTemplate());
+        }
+    }
+
+    @Test
+    @DisplayName("The four controls along the foot clear each other and hold their captions")
+    void theFooterControlsDoNotOverlapOrOverflow() throws Exception {
+        GameData data = load();
+        try (GameLobby lobby = GameLobby.host("Chris", "garden.pud", 8, PORT + 27)) {
+            LobbyScreen screen = new LobbyScreen(data, lobby, "garden.pud", new Recording());
+            screen.render();
+
+            List<Rectangle> feet = List.of(LobbyScreen.startBounds(),
+                    LobbyScreen.templateBounds(), LobbyScreen.speedBounds(),
+                    LobbyScreen.cancelBounds());
+            Rectangle table = LobbyScreen.rowBounds(0);
+            for (int i = 0; i < feet.size(); i++) {
+                Rectangle here = feet.get(i);
+                assertTrue(here.x >= table.x && here.x + here.width <= table.x + table.width,
+                        "footer control " + i + " at " + here + " hangs off the table,"
+                                + " which runs " + table.x + " to " + (table.x + table.width));
+                for (int j = i + 1; j < feet.size(); j++) {
+                    assertFalse(here.intersects(feet.get(j)),
+                            "footer controls " + i + " and " + j + " overlap: "
+                                    + here + " and " + feet.get(j)
+                                    + "; two controls sharing a pixel means one click"
+                                    + " does whichever the screen registered first");
+                }
+            }
+
+            // The buttons draw their captions centred and do not shorten
+            // them, so a caption wider than its panel spills over the bezel
+            // with nothing to stop it. The widths above were measured by hand
+            // against exactly these strings.
+            GameFont face = screen.gameFaceForTest();
+            record Fitted(Rectangle where, String caption) {}
+            List<Fitted> captions = new ArrayList<>();
+            for (String start : List.of("Starting...", "Waiting for Players",
+                    "Assign Opponents", "Start Game", "Syncing Map...")) {
+                captions.add(new Fitted(LobbyScreen.startBounds(), start));
+            }
+            for (GameLobby.GameTemplate mode : GameLobby.GameTemplate.values()) {
+                captions.add(new Fitted(LobbyScreen.templateBounds(),
+                        "Mode: " + mode.caption()));
+            }
+            for (GameLobby.GameSpeed speed : GameLobby.GameSpeed.values()) {
+                captions.add(new Fitted(LobbyScreen.speedBounds(),
+                        "Speed: " + speed.caption()));
+            }
+            for (String end : List.of("Cancel (Esc)", "Quit to Update")) {
+                captions.add(new Fitted(LobbyScreen.cancelBounds(), end));
+            }
+            assertTrue(captions.size() >= 16,
+                    "the sweep collected only " + captions.size() + " captions, so it is"
+                            + " not covering every state the footer can be drawn in");
+            for (Fitted fitted : captions) {
+                assertTrue(face.widthOf(fitted.caption()) <= fitted.where().width - 8,
+                        "\"" + fitted.caption() + "\" draws "
+                                + face.widthOf(fitted.caption()) + " pixels wide in a "
+                                + fitted.where().width + "-pixel panel and would spill"
+                                + " over its bezel");
+            }
         }
     }
 

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/LobbyScreenTest.java
@@ -196,6 +196,34 @@ class LobbyScreenTest {
     }
 
     @Test
+    @DisplayName("The host chooses how fast the whole table will play")
+    void gameSpeedIsChosenBeforeAnybodyStarts() throws Exception {
+        GameData data = null;
+        try (GameLobby lobby = GameLobby.host("Chris", "garden.pud", 8, PORT + 25)) {
+            LobbyScreen screen = new LobbyScreen(data, lobby, "garden.pud", new Recording());
+            screen.render();
+
+            assertEquals(GameLobby.GameSpeed.NORMAL, lobby.state().gameSpeed(),
+                    "a new game opens at the rate the simulation counts in");
+            assertEquals(30, lobby.state().gameSpeed().cyclesPerSecond(),
+                    "Normal is thirty cycles a second, which is what the game is timed in");
+
+            assertTrue(click(screen, LobbyScreen.speedBounds()));
+            assertEquals(GameLobby.GameSpeed.FAST, lobby.state().gameSpeed(),
+                    "the control did not move the tempo on");
+
+            // All the way round, so no setting is a dead end for a host who
+            // clicked past the one they wanted.
+            for (int click = 0; click < GameLobby.GameSpeed.values().length - 1; click++) {
+                screen.render();
+                assertTrue(click(screen, LobbyScreen.speedBounds()));
+            }
+            assertEquals(GameLobby.GameSpeed.NORMAL, lobby.state().gameSpeed(),
+                    "clicking through every speed did not come back round to Normal");
+        }
+    }
+
+    @Test
     @DisplayName("The host assigns teams without changing colour or row")
     void teamsAreExplicitAndIndependentFromColour() throws Exception {
         GameData data = null;
@@ -473,6 +501,8 @@ class LobbyScreenTest {
                     "a joiner was able to pick a player up");
             assertFalse(click(screen, LobbyScreen.templateBounds()),
                     "a joiner was offered the game-template control");
+            assertFalse(click(screen, LobbyScreen.speedBounds()),
+                    "a joiner was offered the game-speed control");
         }
     }
 

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorderTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorderTest.java
@@ -61,7 +61,8 @@ class PassiveMultiplayerRecorderTest {
         // seconds the players spent: at sixty a second this match is half as
         // long as the simulation's own rate would make it look.
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
-                world, "maps/skirmish/FAMILY.PUD", map, 1, 60, 5, 2,
+                world, "maps/skirmish/FAMILY.PUD", map, 1,
+                new PassiveMultiplayerRecorder.Pacing(60, 5, 2),
                 "test-build", root, began);
         Path directory = recorder.directory();
         GameCommand command = GameCommand.move(1, 42, 17, 23).withQueued(true);
@@ -319,7 +320,7 @@ class PassiveMultiplayerRecorderTest {
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
                 world, "maps/skirmish/REPLAY.PUD",
                 new byte[] {0x57, 0x41, 0x52, 0x32, 9, 8, 7},
-                0, 30, 5, 2, "test-build", root,
+                0, new PassiveMultiplayerRecorder.Pacing(30, 5, 2), "test-build", root,
                 Instant.parse("2026-08-27T20:00:00Z"));
         Path directory = recorder.directory();
         try {
@@ -384,7 +385,8 @@ class PassiveMultiplayerRecorderTest {
         CommandApplier applier = new CommandApplier(world, roster);
         data.configureCommands(applier);
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
-                world, mapName, mapBytes, localPlayer, 30, 5, 2,
+                world, mapName, mapBytes, localPlayer,
+                new PassiveMultiplayerRecorder.Pacing(30, 5, 2),
                 "test-build", root, Instant.parse("2026-08-27T20:00:00Z"));
         Path directory = recorder.directory();
         long initialCycle = world.cycle();

--- a/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorderTest.java
+++ b/desktop/src/test/java/net/chonkbase/chonkcraft/desktop/PassiveMultiplayerRecorderTest.java
@@ -56,8 +56,12 @@ class PassiveMultiplayerRecorderTest {
         World world = new World(new GameMap(12, 10, new Tileset()));
         byte[] map = {0x57, 0x41, 0x52, 0x32, 0x01, 0x02};
         Instant began = Instant.parse("2026-08-26T19:20:21.123Z");
+        // Fastest, as a lobby that chose it would open the game. The record
+        // has to say so or a cycle count in it cannot be turned back into the
+        // seconds the players spent: at sixty a second this match is half as
+        // long as the simulation's own rate would make it look.
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
-                world, "maps/skirmish/FAMILY.PUD", map, 1, 5, 2,
+                world, "maps/skirmish/FAMILY.PUD", map, 1, 60, 5, 2,
                 "test-build", root, began);
         Path directory = recorder.directory();
         GameCommand command = GameCommand.move(1, 42, 17, 23).withQueued(true);
@@ -109,6 +113,8 @@ class PassiveMultiplayerRecorderTest {
         String manifest = Files.readString(directory.resolve("manifest.json"));
         assertEquals("complete", json.readTree(manifest).path("status").asText(),
                 "the finished manifest is not valid, structured JSON");
+        assertTrue(manifest.contains("\"cycles_per_second\": 60"),
+                "the record does not say how fast the match was actually played: " + manifest);
         assertTrue(manifest.contains("\"status\": \"complete\"")
                         && manifest.contains("\"recorded_net_cycles\": 2")
                         && manifest.contains("\"recorded_commands\": 1")
@@ -313,7 +319,7 @@ class PassiveMultiplayerRecorderTest {
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
                 world, "maps/skirmish/REPLAY.PUD",
                 new byte[] {0x57, 0x41, 0x52, 0x32, 9, 8, 7},
-                0, 5, 2, "test-build", root,
+                0, 30, 5, 2, "test-build", root,
                 Instant.parse("2026-08-27T20:00:00Z"));
         Path directory = recorder.directory();
         try {
@@ -378,7 +384,7 @@ class PassiveMultiplayerRecorderTest {
         CommandApplier applier = new CommandApplier(world, roster);
         data.configureCommands(applier);
         PassiveMultiplayerRecorder recorder = PassiveMultiplayerRecorder.open(
-                world, mapName, mapBytes, localPlayer, 5, 2,
+                world, mapName, mapBytes, localPlayer, 30, 5, 2,
                 "test-build", root, Instant.parse("2026-08-27T20:00:00Z"));
         Path directory = recorder.directory();
         long initialCycle = world.cycle();

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -524,9 +524,9 @@ re-baseline the counts.
 The hosted, data-free job runs on every push and pull request. A private
 authenticated job runs only for `master` pushes or a maintainer's manual
 dispatch, using a read-only copy of the installation and authenticated pack.
-It asserts 1,363 skips, so 1,649 tests actually run without exposing licensed
+It asserts 1,364 skips, so 1,653 tests actually run without exposing licensed
 media to public pull-request code. The authenticated lane asserts 27 skips out
-of at least 3,012 tests; a development machine with the three private playtest-save
+of at least 3,017 tests; a development machine with the three private playtest-save
 referees installed uses `full-with-playtest-saves` and asserts 24. An exact BNE
 source plus matching pack and those saves uses
 `full-bne-with-playtest-saves` and asserts 30 release-format-specific skips.

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -524,9 +524,9 @@ re-baseline the counts.
 The hosted, data-free job runs on every push and pull request. A private
 authenticated job runs only for `master` pushes or a maintainer's manual
 dispatch, using a read-only copy of the installation and authenticated pack.
-It asserts 1,364 skips, so 1,653 tests actually run without exposing licensed
+It asserts 1,366 skips, so 1,654 tests actually run without exposing licensed
 media to public pull-request code. The authenticated lane asserts 27 skips out
-of at least 3,017 tests; a development machine with the three private playtest-save
+of at least 3,020 tests; a development machine with the three private playtest-save
 referees installed uses `full-with-playtest-saves` and asserts 24. An exact BNE
 source plus matching pack and those saves uses
 `full-bne-with-playtest-saves` and asserts 30 release-format-specific skips.

--- a/docs/multiplayer-matchmaking.md
+++ b/docs/multiplayer-matchmaking.md
@@ -198,6 +198,7 @@ Retail's own lobby carries a game-speed byte with nine values at offset
 not been read out of the pinned executable. These seven steps are therefore
 this implementation's own, and the wall-clock tempo of every setting except
 Normal is a choice rather than a measurement.
+
 `MultiplayerVisualTest` renders the online browser, local fallback,
 invite lobby, and the retry/local recovery screen at design, laptop, and
 widescreen sizes for image review.

--- a/docs/multiplayer-matchmaking.md
+++ b/docs/multiplayer-matchmaking.md
@@ -87,7 +87,7 @@ The rule is enforced in two independent places:
 
 1. The online room directory filters browsing by build and returns HTTP 426 to
    a code join from another build. No relay seat or ticket is issued.
-2. Lobby wire version 7 carries the build in `JOIN`, authoritative `STATE`, and
+2. Lobby wire version 8 carries the build in `JOIN`, authoritative `STATE`, and
    `START`. A direct or relayed host compares it before allocating a player
    slot. A rejected peer receives no roster seat, map chunk, readiness state,
    or start packet.
@@ -179,6 +179,25 @@ proves exactly one mutual human teammate with shared vision, exactly one mutual
 computer enemy with its retail `ai.bin` profile active, and matching final
 simulation hashes after 180 cycles. Diplomacy and shared sight are themselves
 part of that hash from cycle zero.
+
+The lobby also settles the **game speed**, seven named steps from Slowest to
+Fastest, and every machine opens its simulation loop at the one the host chose.
+Speed is tempo and not simulation: `World.CYCLES_PER_SECOND` stays 30 and each
+step is a plain ratio of it, so a match plays the same cycles either way and
+only plays them faster or slower. It belongs to the table rather than to one
+player because lockstep holds every machine at a net cycle boundary until the
+slowest has reported: a client that slows only itself slows everybody's game by
+the same amount, with nothing on the other screens to say why. The in-game
+speed control therefore names the host's setting in a network game instead of
+offering a slider, the way Pause already refuses. The two-process gate proves
+it: the host picks Fastest and the joiner, which is never told a speed, reports
+60 cycles a second off its own running game.
+
+Retail's own lobby carries a game-speed byte with nine values at offset
+`0x1F4` of a Battle.net Edition replay header, indexing a pacing table that has
+not been read out of the pinned executable. These seven steps are therefore
+this implementation's own, and the wall-clock tempo of every setting except
+Normal is a choice rather than a measurement.
 `MultiplayerVisualTest` renders the online browser, local fallback,
 invite lobby, and the retry/local recovery screen at design, laptop, and
 widescreen sizes for image review.

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/GameLobby.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/GameLobby.java
@@ -53,10 +53,10 @@ public final class GameLobby implements Closeable {
     /** Marks a packet as ours and pins the wire format. */
     private static final int MAGIC = 0x57474C59; // "WGLY"
 
-    // Version 7 carries an explicit team number for every slot. A different
-    // build is not allowed to receive a slot, map bytes or START: deterministic
-    // peers must run identical gameplay code.
-    private static final int VERSION = 7;
+    // Version 8 carries the agreed game speed beside the game type. A
+    // different build is not allowed to receive a slot, map bytes or START:
+    // deterministic peers must run identical gameplay code.
+    private static final int VERSION = 8;
 
     private static final int MAX_PACKET_BYTES = 1200;
 
@@ -127,6 +127,86 @@ public final class GameLobby implements Closeable {
     }
 
     /**
+     * How fast the match runs, chosen once by whoever created the game.
+     *
+     * <p>Tempo, not simulation. {@code World.CYCLES_PER_SECOND} stays 30 --
+     * unit speeds, build times and spell durations are all counted in cycles
+     * -- and this only says how many of those cycles a second each machine
+     * plays. Every step is a plain ratio of that rate, which is why the
+     * numbers are what they are and not a curve.
+     *
+     * <p>Agreed in the lobby rather than left to each player, because a
+     * network game runs no faster than its slowest machine. Lockstep will not
+     * pass a net cycle boundary until every player's commands for it have
+     * arrived, so a player who drags their own speed down to a third is not
+     * slowing their own game: they are slowing everybody's, to a third, with
+     * nothing on anyone else's screen to say why. Two machines cannot play one
+     * match at two tempos, so the lobby is where the choice belongs.
+     *
+     * <p>Deviation, stated: the retail lobby carries a game-speed byte with
+     * nine values, 0 through 8, at offset {@code 0x1F4} of a Battle.net
+     * Edition replay header, and it indexes a pacing table that has not yet
+     * been read out of the pinned executable. This offers seven named steps
+     * of its own instead, so the wall-clock tempo of every setting except
+     * Normal is this implementation's choice rather than a measured one.
+     */
+    public enum GameSpeed {
+        /** A third of the simulation rate. */
+        SLOWEST("Slowest", 10),
+        /** Half of it. */
+        SLOWER("Slower", 15),
+        /** Three quarters. */
+        SLOW("Slow", 22),
+        /** The rate the simulation counts in, and the only measured one. */
+        NORMAL("Normal", 30),
+        /** Four thirds. */
+        FAST("Fast", 40),
+        /** Five thirds. */
+        FASTER("Faster", 50),
+        /** Twice the simulation rate. */
+        FASTEST("Fastest", 60);
+
+        private final String caption;
+        private final int cyclesPerSecond;
+
+        GameSpeed(String caption, int cyclesPerSecond) {
+            this.caption = caption;
+            this.cyclesPerSecond = cyclesPerSecond;
+        }
+
+        public String caption() {
+            return caption;
+        }
+
+        /** How many simulation cycles a second every machine plays. */
+        public int cyclesPerSecond() {
+            return cyclesPerSecond;
+        }
+
+        public GameSpeed next() {
+            GameSpeed[] speeds = values();
+            return speeds[(ordinal() + 1) % speeds.length];
+        }
+
+        /**
+         * The setting that plays this many cycles a second.
+         *
+         * <p>So the running game can name the host's choice back to the
+         * player. A rate no setting produces answers Normal rather than
+         * nothing: this is a caption, and a game that cannot say what speed
+         * it is running at is worse than one that rounds.
+         */
+        public static GameSpeed of(int cyclesPerSecond) {
+            for (GameSpeed speed : values()) {
+                if (speed.cyclesPerSecond == cyclesPerSecond) {
+                    return speed;
+                }
+            }
+            return NORMAL;
+        }
+    }
+
+    /**
      * One line of the lobby.
      *
      * @param index    the player slot, which is also the colour
@@ -156,6 +236,7 @@ public final class GameLobby implements Closeable {
 
     /** Everything a screen needs to draw the lobby. */
     public record State(String map, List<Slot> slots, GameTemplate gameTemplate,
+            GameSpeed gameSpeed,
             int localSlot, int hostSlot, boolean started, boolean mapReady, int mapPercent,
             boolean allPlayersReady, String mapProblem, String localBuild, String requiredBuild) {
 
@@ -211,6 +292,7 @@ public final class GameLobby implements Closeable {
     private String map;
     private String localName;
     private GameTemplate gameTemplate = GameTemplate.MELEE;
+    private GameSpeed gameSpeed = GameSpeed.NORMAL;
 
     /** The slots, index 0 to capacity - 1. */
     private final List<Slot> slots = new ArrayList<>();
@@ -398,7 +480,7 @@ public final class GameLobby implements Closeable {
                 ? connectionWarning(localSlot, mapReady, openedAt, lastMapProgressAt,
                         hostPort(), System.currentTimeMillis(), relayed)
                 : mapProblem;
-        return new State(map, List.copyOf(slots), gameTemplate, localSlot,
+        return new State(map, List.copyOf(slots), gameTemplate, gameSpeed, localSlot,
                 hosting ? localSlot : remoteHostSlot, started,
                 mapReady, mapPercent(), hosting ? everyHumanHasMap() : allPlayersReady,
                 problem, gameBuild, requiredBuild);
@@ -578,6 +660,23 @@ public final class GameLobby implements Closeable {
             return false;
         }
         gameTemplate = template;
+        lastSent = 0;
+        return true;
+    }
+
+    /**
+     * Selects the tempo every machine will play at. Only the creator decides it.
+     *
+     * <p>Refused once the game has started, like the rest of the agreement:
+     * the speed travels in the START snapshot and each machine sets its loop
+     * from it, so a later change would reach the players who were still
+     * listening and nobody else.
+     */
+    public synchronized boolean setGameSpeed(GameSpeed speed) {
+        if (!hosting || speed == null || started) {
+            return false;
+        }
+        gameSpeed = speed;
         lastSent = 0;
         return true;
     }
@@ -826,6 +925,7 @@ public final class GameLobby implements Closeable {
         buffer.put(mapHash.length == 32 ? mapHash : new byte[32]);
         buffer.put((byte) (everyHumanHasMap() ? 1 : 0));
         buffer.put((byte) gameTemplate.ordinal());
+        buffer.put((byte) gameSpeed.ordinal());
         buffer.put((byte) slots.size());
         for (Slot slot : slots) {
             buffer.put((byte) slot.occupant().ordinal());
@@ -1079,7 +1179,7 @@ public final class GameLobby implements Closeable {
             return;
         }
         String heardMap = readString(in);
-        if (in.remaining() < Integer.BYTES + 32 + 3) {
+        if (in.remaining() < Integer.BYTES + 32 + 4) {
             return;
         }
         int heardLength = in.getInt();
@@ -1090,6 +1190,10 @@ public final class GameLobby implements Closeable {
         GameTemplate heardTemplate = templateOrdinal < GameTemplate.values().length
                 ? GameTemplate.values()[templateOrdinal]
                 : GameTemplate.MELEE;
+        int speedOrdinal = in.get() & 0xFF;
+        GameSpeed heardSpeed = speedOrdinal < GameSpeed.values().length
+                ? GameSpeed.values()[speedOrdinal]
+                : GameSpeed.NORMAL;
         int count = in.get() & 0xFF;
         List<Slot> heard = new ArrayList<>(count);
         for (int i = 0; i < count; i++) {
@@ -1107,6 +1211,7 @@ public final class GameLobby implements Closeable {
         remoteHostSlot = heardHostSlot;
         map = heardMap == null ? "" : heardMap;
         gameTemplate = heardTemplate;
+        gameSpeed = heardSpeed;
         slots.clear();
         slots.addAll(heard);
         allPlayersReady = heardAllReady;

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/GameLobby.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/GameLobby.java
@@ -187,23 +187,6 @@ public final class GameLobby implements Closeable {
             GameSpeed[] speeds = values();
             return speeds[(ordinal() + 1) % speeds.length];
         }
-
-        /**
-         * The setting that plays this many cycles a second.
-         *
-         * <p>So the running game can name the host's choice back to the
-         * player. A rate no setting produces answers Normal rather than
-         * nothing: this is a caption, and a game that cannot say what speed
-         * it is running at is worse than one that rounds.
-         */
-        public static GameSpeed of(int cyclesPerSecond) {
-            for (GameSpeed speed : values()) {
-                if (speed.cyclesPerSecond == cyclesPerSecond) {
-                    return speed;
-                }
-            }
-            return NORMAL;
-        }
     }
 
     /**
@@ -656,7 +639,7 @@ public final class GameLobby implements Closeable {
 
     /** Selects the synchronized game type. Only the creator decides it. */
     public synchronized boolean setGameTemplate(GameTemplate template) {
-        if (!hosting || template == null) {
+        if (!hosting || template == null || started) {
             return false;
         }
         gameTemplate = template;
@@ -667,10 +650,12 @@ public final class GameLobby implements Closeable {
     /**
      * Selects the tempo every machine will play at. Only the creator decides it.
      *
-     * <p>Refused once the game has started, like the rest of the agreement:
-     * the speed travels in the START snapshot and each machine sets its loop
-     * from it, so a later change would reach the players who were still
-     * listening and nobody else.
+     * <p>Refused once the game has started, as the game type beside it is.
+     * Both travel in the START snapshot and each machine builds its world
+     * from what that snapshot said, so a change made afterwards reaches the
+     * peers still polling the lobby and none of the ones that have already
+     * taken their socket into the game -- which is two machines starting
+     * different matches.
      */
     public synchronized boolean setGameSpeed(GameSpeed speed) {
         if (!hosting || speed == null || started) {

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/NetworkGame.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/NetworkGame.java
@@ -203,6 +203,26 @@ public final class NetworkGame implements AutoCloseable {
         this.hostPlayer = hostPlayer;
     }
 
+    /**
+     * How many cycles a second every machine in this match plays.
+     *
+     * <p>Tempo, not simulation: the world still counts in cycles at
+     * {@code World.CYCLES_PER_SECOND}, and this only says how quickly they
+     * are played. It rides here because it is part of what the lobby settled,
+     * and because a match has exactly one of it -- lockstep will not pass a
+     * net cycle boundary until every player has reported, so a machine set
+     * slower than the rest sets the pace for all of them.
+     */
+    private int cyclesPerSecond = World.CYCLES_PER_SECOND;
+
+    public void setCyclesPerSecond(int cyclesPerSecond) {
+        this.cyclesPerSecond = Math.max(1, cyclesPerSecond);
+    }
+
+    public int cyclesPerSecond() {
+        return cyclesPerSecond;
+    }
+
     /** Installs a passive observer of completed lockstep cycles. */
     public void setCycleSink(CycleSink cycleSink) {
         this.cycleSink = java.util.Objects.requireNonNull(cycleSink, "cycleSink");
@@ -607,6 +627,18 @@ public final class NetworkGame implements AutoCloseable {
                 hostLost = true;
             }
         }
+    }
+
+    /**
+     * What to call a player in a message.
+     *
+     * <p>The lobby name when there is one, and the slot counted from one when
+     * there is not. Never the raw slot index: the interface counts players
+     * from one everywhere else, so a message that says "player 1" about the
+     * machine in slot 1 is talking about player 2.
+     */
+    public String nameOfPlayer(int player) {
+        return playerName(player);
     }
 
     private String playerName(int player) {

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/NetworkGame.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/NetworkGame.java
@@ -88,7 +88,21 @@ public final class NetworkGame implements AutoCloseable {
     /** Our own hash at each net cycle, kept to compare against theirs. */
     private final java.util.Map<Long, Long> ownHashes = new java.util.HashMap<>();
 
+    /**
+     * The game cycle each of those hashes was taken at.
+     *
+     * <p>Kept because the two numbers are five apart and a player reports
+     * whichever one they were shown. Commands are batched into net cycles and
+     * the world runs {@code cyclesPerUpdate} of its own between them, so a
+     * divergence at net cycle 2,125 is a divergence at game cycle 10,626, and
+     * a report of "cycle 2125" matched nothing anybody could look up: not the
+     * cycle a save counts in, and not the {@code world_cycle} beside it in the
+     * flight record.
+     */
+    private final java.util.Map<Long, Long> ownWorldCycles = new java.util.HashMap<>();
+
     private long desyncCycle = -1;
+    private long desyncWorldCycle = -1;
     private int desyncPlayer = -1;
     private int hostPlayer = -1;
     private boolean hostLost;
@@ -213,14 +227,19 @@ public final class NetworkGame implements AutoCloseable {
      * net cycle boundary until every player has reported, so a machine set
      * slower than the rest sets the pace for all of them.
      */
-    private int cyclesPerSecond = World.CYCLES_PER_SECOND;
+    private GameLobby.GameSpeed gameSpeed = GameLobby.GameSpeed.NORMAL;
 
-    public void setCyclesPerSecond(int cyclesPerSecond) {
-        this.cyclesPerSecond = Math.max(1, cyclesPerSecond);
+    public void setGameSpeed(GameLobby.GameSpeed gameSpeed) {
+        this.gameSpeed = java.util.Objects.requireNonNull(gameSpeed, "gameSpeed");
+    }
+
+    /** The setting itself, so the running game can name it without guessing. */
+    public GameLobby.GameSpeed gameSpeed() {
+        return gameSpeed;
     }
 
     public int cyclesPerSecond() {
-        return cyclesPerSecond;
+        return gameSpeed.cyclesPerSecond();
     }
 
     /** Installs a passive observer of completed lockstep cycles. */
@@ -346,6 +365,17 @@ public final class NetworkGame implements AutoCloseable {
         return desyncCycle;
     }
 
+    /**
+     * The game cycle that net cycle's hash was taken at, or {@code -1}.
+     *
+     * <p>The number a player can act on. It is what a save counts in, what
+     * {@code World.cycle()} shows, and what the flight record files beside
+     * the net cycle.
+     */
+    public long desyncWorldCycle() {
+        return desyncWorldCycle;
+    }
+
     /** Which machine disagreed, or {@code -1}. */
     public int desyncPlayer() {
         return desyncPlayer;
@@ -413,6 +443,7 @@ public final class NetworkGame implements AutoCloseable {
 
         long hash = SyncHash.of(world);
         ownHashes.put(netCycle, hash);
+        ownWorldCycles.put(netCycle, world.cycle());
         // Keep a window rather than discarding everything we have passed. A
         // peer behind us still needs the batches we have already used, and
         // purging by our own progress is what leaves it stuck forever: we move
@@ -420,6 +451,7 @@ public final class NetworkGame implements AutoCloseable {
         // can recover.
         sentBatches.keySet().removeIf(cycle -> cycle < netCycle - RESEND_WINDOW);
         ownHashes.keySet().removeIf(cycle -> cycle < netCycle - RESEND_WINDOW);
+        ownWorldCycles.keySet().removeIf(cycle -> cycle < netCycle - RESEND_WINDOW);
         reportedHashes.keySet().removeIf(cycle -> cycle < netCycle - RESEND_WINDOW);
         checkHashes(netCycle, hash);
         try {
@@ -637,11 +669,7 @@ public final class NetworkGame implements AutoCloseable {
      * from one everywhere else, so a message that says "player 1" about the
      * machine in slot 1 is talking about player 2.
      */
-    public String nameOfPlayer(int player) {
-        return playerName(player);
-    }
-
-    private String playerName(int player) {
+    public String playerName(int player) {
         String name = playerNames.get(player);
         return name == null || name.isBlank() ? "Player " + (player + 1) : name;
     }
@@ -777,6 +805,7 @@ public final class NetworkGame implements AutoCloseable {
             // Zero means the sender had not finished a cycle yet.
             if (entry.getValue() != 0L && entry.getValue() != ourHash) {
                 desyncCycle = netCycle;
+                desyncWorldCycle = ownWorldCycles.getOrDefault(netCycle, -1L);
                 desyncPlayer = entry.getKey();
                 return;
             }

--- a/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/SyncHash.java
+++ b/engine/src/main/java/net/chonkbase/chonkcraft/engine/network/SyncHash.java
@@ -19,7 +19,8 @@ import net.chonkbase.chonkcraft.engine.unit.UnitType;
  * simulation decides, so a divergence is caught, and nothing that is merely
  * presentational, or two machines with different window sizes would appear to
  * disagree. So: terrain state, unit positions, health, orders and ownership,
- * and the players' banks. Not animation frames, not the camera, not sound.
+ * the players' banks, and both random streams. Not animation frames, not the
+ * camera, not sound.
  */
 public final class SyncHash {
 
@@ -30,7 +31,7 @@ public final class SyncHash {
      * operation changes. Persisted hashes without this identity are useful for
      * diagnostics, but cannot prove an exact replay under a later engine.
      */
-    public static final int SCHEMA = 2;
+    public static final int SCHEMA = 3;
 
     private SyncHash() {
     }
@@ -49,6 +50,18 @@ public final class SyncHash {
         hash = mix(hash, world.cycle());
         hash = mix(hash, world.randomSeed());
         hash = mix(hash, world.randomDraws());
+        // Both streams, because both decide the game. "Asynchronous" is the
+        // original's name for the second generator, not a statement that it
+        // may drift: battleNetMeleeDamage rolls every melee hit out of it --
+        // half + AsyncRand() % (half + 1) -- and so do unit headings, idle
+        // wandering, harvest approach, projectile motion and every computer
+        // player's decision. It used to be left out, and a machine that had
+        // drawn one extra number then went on agreeing about the world until
+        // the difference happened to move a hit point. A player who reported
+        // "desynchronised at cycle 2125" was naming a cycle minutes after the
+        // one that went wrong, which is why nothing could be done with it.
+        hash = mix(hash, world.battleNetRandomSeed());
+        hash = mix(hash, world.battleNetRandomDraws());
 
         hash = mix(hash, world.map().width());
         hash = mix(hash, world.map().height());

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LobbyToGameTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LobbyToGameTest.java
@@ -2,6 +2,7 @@ package net.chonkbase.chonkcraft.engine.network;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,6 +103,52 @@ class LobbyToGameTest {
         game.setHostPlayer(state.hostSlot());
         game.start();
         return new Machine(game, world, state.localSlot());
+    }
+
+    @Test
+    @DisplayName("the speed the host picks is the speed every player joins at")
+    void theHostsChosenSpeedReachesEveryPlayer() throws Exception {
+        InetAddress local = InetAddress.getLoopbackAddress();
+        byte[] hostedMap = new byte[4_000];
+        GameLobby hostLobby = GameLobby.host("Chris", "garden.pud", hostedMap, 8, 0);
+        GameLobby annLobby = GameLobby.join("Ann", local, hostLobby.connectionPort(),
+                name -> null);
+        try {
+            pollUntil("everyone seated", () -> hostLobby.humanCount() == 2,
+                    hostLobby, annLobby);
+            assertEquals(GameLobby.GameSpeed.NORMAL, annLobby.state().gameSpeed(),
+                    "a game nobody has changed opens at the rate the simulation counts in");
+
+            assertTrue(hostLobby.setGameSpeed(GameLobby.GameSpeed.FASTEST),
+                    "the host must be able to choose the tempo of the game it created");
+            pollUntil("the joiner heard the chosen speed",
+                    () -> annLobby.state().gameSpeed() == GameLobby.GameSpeed.FASTEST,
+                    hostLobby, annLobby);
+            assertEquals(60, annLobby.state().gameSpeed().cyclesPerSecond(),
+                    "Fastest plays sixty cycles a second on every machine at the table");
+
+            // A joiner may watch the choice and may not make it. Two players
+            // cannot run one match at two tempos: lockstep holds everybody at
+            // a net cycle boundary until the slowest has reported.
+            assertFalse(annLobby.setGameSpeed(GameLobby.GameSpeed.SLOWEST),
+                    "a player who did not create the game must not set its speed");
+            pollUntil("the host is unmoved",
+                    () -> hostLobby.state().gameSpeed() == GameLobby.GameSpeed.FASTEST,
+                    hostLobby, annLobby);
+
+            // The commit record carries it too, so a host that starts before
+            // its last ordinary state packet lands still starts everybody at
+            // the speed it chose.
+            hostLobby.setGameSpeed(GameLobby.GameSpeed.SLOW);
+            hostLobby.start();
+            pollUntil("the joiner heard the start",
+                    () -> annLobby.isStarted(), hostLobby, annLobby);
+            assertEquals(GameLobby.GameSpeed.SLOW, annLobby.state().gameSpeed(),
+                    "the started game must run at the speed the host settled on");
+        } finally {
+            hostLobby.close();
+            annLobby.close();
+        }
     }
 
     @Test

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LockstepTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LockstepTest.java
@@ -333,6 +333,101 @@ class LockstepTest {
     }
 
     @Test
+    @DisplayName("a peer playing three cycles for every one of its opponent's ends in the same game")
+    void anUnevenTempoBetweenPeersDoesNotChangeTheGame() throws Exception {
+        // What a player who changes the game speed actually changes: how
+        // often their own machine is given a turn. It was suspected of
+        // desynchronising a match, and it cannot, because the boundary is
+        // where the agreement is -- a machine offered more turns spends the
+        // extra ones waiting. The speed is agreed in the lobby now, but an
+        // uneven tempo still happens by itself on a busy or slow machine, so
+        // this stays as the statement that it is harmless.
+        World hostWorld = battlefield();
+        World guestWorld = battlefield();
+        UnitType hostType = hostWorld.units().getFirst().type();
+        UnitType guestType = guestWorld.units().getFirst().type();
+
+        try (NetworkSession hostSession = new NetworkSession(0, 0);
+                NetworkSession guestSession = new NetworkSession(1, 0)) {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            hostSession.addPeer(1, loopback, guestSession.localPort());
+            guestSession.addPeer(0, loopback, hostSession.localPort());
+            NetworkGame host = new NetworkGame(hostWorld, hostSession,
+                    new LockstepScheduler(2),
+                    new CommandApplier(hostWorld, List.of(hostType)), 0);
+            NetworkGame guest = new NetworkGame(guestWorld, guestSession,
+                    new LockstepScheduler(2),
+                    new CommandApplier(guestWorld, List.of(guestType)), 1);
+            host.start();
+            guest.start();
+
+            java.util.Set<Long> issued = new java.util.HashSet<>();
+            int attempts = 0;
+            while ((hostWorld.cycle() < 900 || guestWorld.cycle() < 900)
+                    && attempts++ < 40_000) {
+                if (hostWorld.cycle() == guestWorld.cycle()
+                        && issued.add(hostWorld.cycle())) {
+                    long cycle = hostWorld.cycle();
+                    if (cycle == 0) {
+                        for (int id : List.of(1, 3, 5, 7)) {
+                            host.issue(GameCommand.attackMove(0, id, 20, 20));
+                        }
+                        for (int id : List.of(2, 4, 6, 8)) {
+                            guest.issue(GameCommand.attackMove(1, id, 20, 20));
+                        }
+                    } else if (cycle == 300) {
+                        host.issue(GameCommand.attack(0, 3, 4));
+                        guest.issue(GameCommand.attack(1, 4, 3));
+                    }
+                }
+
+                // The fast machine, three turns to the slow one's.
+                for (int turn = 0; turn < 3; turn++) {
+                    assertNotEquals(NetworkGame.Step.DESYNC, host.update(),
+                            "the faster peer reported a desync at " + host.desyncCycle());
+                }
+                assertNotEquals(NetworkGame.Step.DESYNC, guest.update(),
+                        "the slower peer reported a desync at " + guest.desyncCycle());
+
+                // The extra turns buy a bounded lead and nothing else. A
+                // command is scheduled two net cycles ahead, so a machine can
+                // play out the batches already agreed and then has to stop:
+                // two net cycles of commands, plus the cycles inside the one
+                // it is in the middle of.
+                int lead = (LockstepScheduler.DEFAULT_LAG + 1)
+                        * LockstepScheduler.DEFAULT_CYCLES_PER_UPDATE;
+                assertTrue(Math.abs(hostWorld.cycle() - guestWorld.cycle()) <= lead,
+                        "the faster peer ran past the cycles its opponent had agreed to:"
+                                + " fast=" + hostWorld.cycle() + " slow=" + guestWorld.cycle());
+                if (hostWorld.cycle() == guestWorld.cycle()) {
+                    assertEquals(SyncHash.of(hostWorld), SyncHash.of(guestWorld),
+                            "the two players saw different battles at game cycle "
+                                    + hostWorld.cycle());
+                }
+            }
+
+            assertTrue(hostWorld.cycle() >= 900,
+                    "the faster peer only reached cycle " + hostWorld.cycle());
+            assertTrue(guestWorld.cycle() >= 900,
+                    "the slower peer only reached cycle " + guestWorld.cycle());
+
+            // The lead is a lead, not a divergence: let the slower machine
+            // finish the cycles already agreed and the two must be the same
+            // game again.
+            int settling = 0;
+            while (guestWorld.cycle() < hostWorld.cycle() && settling++ < 10_000) {
+                guest.update();
+            }
+            assertEquals(hostWorld.cycle(), guestWorld.cycle(),
+                    "the slower peer never caught up on cycles that were already agreed");
+            assertEquals(SyncHash.of(hostWorld), SyncHash.of(guestWorld),
+                    "an uneven tempo left the two players in different games");
+            assertEquals(-1, host.desyncCycle());
+            assertEquals(-1, guest.desyncCycle());
+        }
+    }
+
+    @Test
     @DisplayName("chat reaches the other peer without changing or waiting on the world")
     void chatIsSideBandAndAuthenticated() throws Exception {
         World hostWorld = battlefield();
@@ -636,6 +731,26 @@ class LockstepTest {
 
         assertNotEquals(SyncHash.of(first), SyncHash.of(second),
                 "different future random results must be reported as a desync");
+    }
+
+    @Test
+    @DisplayName("the multiplayer hash covers the stream every melee blow is rolled from")
+    void theHashCoversTheAsynchronousRandomStream() {
+        World first = battlefield();
+        World second = battlefield();
+        assertEquals(SyncHash.of(first), SyncHash.of(second));
+
+        // One number out of the second generator, which is what a single
+        // melee blow costs: the damage a footman does is half its maximum
+        // plus a draw from this stream, and so are unit headings, idle
+        // wandering, harvest approach, projectile motion and every decision a
+        // computer player makes.
+        first.battleNetRandomForAi();
+
+        assertNotEquals(SyncHash.of(first), SyncHash.of(second),
+                "a machine one melee roll ahead of the others must be caught on the cycle"
+                        + " it went wrong, not minutes later when the roll first moves a"
+                        + " hit point");
     }
 
     @Test

--- a/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LockstepTest.java
+++ b/engine/src/test/java/net/chonkbase/chonkcraft/engine/network/LockstepTest.java
@@ -3,6 +3,7 @@ package net.chonkbase.chonkcraft.engine.network;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -361,33 +362,76 @@ class LockstepTest {
             host.start();
             guest.start();
 
-            java.util.Set<Long> issued = new java.util.HashSet<>();
+            // Each machine gives its own orders when its own world reaches a
+            // checkpoint. Waiting for the two to be level, which is what this
+            // used to do, is waiting for something an uneven tempo does not
+            // produce: the peers were never level after the opening cycle, so
+            // the comparison inside the loop ran no times at all and the test
+            // was green on its closing assertion alone.
+            java.util.Set<Long> hostIssued = new java.util.HashSet<>();
+            java.util.Set<Long> guestIssued = new java.util.HashSet<>();
+            // The faster machine's world at every cycle it played, so the
+            // slower one can be held to it when it arrives. Two peers never
+            // stand on the same cycle at the same instant here; they stand on
+            // the same cycle at different instants, and that is the thing
+            // lockstep actually promises.
+            java.util.Map<Long, Long> fastWorldByCycle = new java.util.HashMap<>();
+            int ordersIssued = 0;
+            int comparisons = 0;
             int attempts = 0;
             while ((hostWorld.cycle() < 900 || guestWorld.cycle() < 900)
                     && attempts++ < 40_000) {
-                if (hostWorld.cycle() == guestWorld.cycle()
-                        && issued.add(hostWorld.cycle())) {
+                if (hostIssued.add(hostWorld.cycle())) {
                     long cycle = hostWorld.cycle();
                     if (cycle == 0) {
                         for (int id : List.of(1, 3, 5, 7)) {
                             host.issue(GameCommand.attackMove(0, id, 20, 20));
                         }
+                        ordersIssued += 4;
+                    } else if (cycle % 150 == 0) {
+                        host.issue(GameCommand.attack(0, 3, 4));
+                        ordersIssued++;
+                    }
+                }
+                if (guestIssued.add(guestWorld.cycle())) {
+                    long cycle = guestWorld.cycle();
+                    if (cycle == 0) {
                         for (int id : List.of(2, 4, 6, 8)) {
                             guest.issue(GameCommand.attackMove(1, id, 20, 20));
                         }
-                    } else if (cycle == 300) {
-                        host.issue(GameCommand.attack(0, 3, 4));
+                        ordersIssued += 4;
+                    } else if (cycle % 150 == 0) {
                         guest.issue(GameCommand.attack(1, 4, 3));
+                        ordersIssued++;
                     }
                 }
 
-                // The fast machine, three turns to the slow one's.
+                // The fast machine, three turns to the slow one's. Every
+                // cycle it passes through is kept, not just the one it ends a
+                // burst on: recording only the last of three left two cycles
+                // in every three with nothing for the slow machine to be held
+                // to, and 359 of the match's 900 cycles went unchecked.
                 for (int turn = 0; turn < 3; turn++) {
+                    long fastBefore = hostWorld.cycle();
                     assertNotEquals(NetworkGame.Step.DESYNC, host.update(),
                             "the faster peer reported a desync at " + host.desyncCycle());
+                    if (hostWorld.cycle() != fastBefore) {
+                        fastWorldByCycle.put(hostWorld.cycle(), SyncHash.of(hostWorld));
+                    }
                 }
+
+                long slowBefore = guestWorld.cycle();
                 assertNotEquals(NetworkGame.Step.DESYNC, guest.update(),
                         "the slower peer reported a desync at " + guest.desyncCycle());
+                if (guestWorld.cycle() != slowBefore) {
+                    Long fast = fastWorldByCycle.get(guestWorld.cycle());
+                    if (fast != null) {
+                        comparisons++;
+                        assertEquals(fast.longValue(), SyncHash.of(guestWorld),
+                                "the two players saw different battles at game cycle "
+                                        + guestWorld.cycle());
+                    }
+                }
 
                 // The extra turns buy a bounded lead and nothing else. A
                 // command is scheduled two net cycles ahead, so a machine can
@@ -399,29 +443,47 @@ class LockstepTest {
                 assertTrue(Math.abs(hostWorld.cycle() - guestWorld.cycle()) <= lead,
                         "the faster peer ran past the cycles its opponent had agreed to:"
                                 + " fast=" + hostWorld.cycle() + " slow=" + guestWorld.cycle());
-                if (hostWorld.cycle() == guestWorld.cycle()) {
-                    assertEquals(SyncHash.of(hostWorld), SyncHash.of(guestWorld),
-                            "the two players saw different battles at game cycle "
-                                    + hostWorld.cycle());
-                }
             }
+
+            assertTrue(comparisons >= 800,
+                    "only " + comparisons + " of the match's 900 cycles were ever compared"
+                            + " between the two peers, so this measured almost nothing");
+            assertTrue(ordersIssued >= 14,
+                    "only " + ordersIssued + " orders were given, so the uneven tempo was"
+                            + " measured against an empty field rather than a battle");
+            assertTrue(hostWorld.units().size() < 8 || guestWorld.units().size() < 8
+                            || hostWorld.randomDraws() > 0,
+                    "nothing was ever rolled, so the two armies never actually fought");
 
             assertTrue(hostWorld.cycle() >= 900,
                     "the faster peer only reached cycle " + hostWorld.cycle());
             assertTrue(guestWorld.cycle() >= 900,
                     "the slower peer only reached cycle " + guestWorld.cycle());
 
-            // The lead is a lead, not a divergence: let the slower machine
-            // finish the cycles already agreed and the two must be the same
-            // game again.
+            // The lead is a lead, not a divergence: the slower machine
+            // finishes the cycles already agreed and arrives in the same
+            // game. Settled against the cycle the faster peer had reached
+            // when this started, not against a moving one -- both peers keep
+            // taking turns here, because resends are driven from the sender's
+            // own update() and pumping only the slower machine leaves it
+            // waiting forever for a batch the loopback dropped, but that also
+            // means the faster one goes on climbing and a chase after its
+            // live cycle never ends.
+            long agreed = hostWorld.cycle();
             int settling = 0;
-            while (guestWorld.cycle() < hostWorld.cycle() && settling++ < 10_000) {
+            while (guestWorld.cycle() < agreed && settling++ < 20_000) {
                 guest.update();
+                host.update();
             }
-            assertEquals(hostWorld.cycle(), guestWorld.cycle(),
+            assertEquals(agreed, guestWorld.cycle(),
                     "the slower peer never caught up on cycles that were already agreed");
-            assertEquals(SyncHash.of(hostWorld), SyncHash.of(guestWorld),
-                    "an uneven tempo left the two players in different games");
+            Long fastAtAgreed = fastWorldByCycle.get(agreed);
+            assertNotNull(fastAtAgreed,
+                    "the faster peer's world at cycle " + agreed + " was never recorded,"
+                            + " so there is nothing to hold the slower one to");
+            assertEquals(fastAtAgreed.longValue(), SyncHash.of(guestWorld),
+                    "an uneven tempo left the two players in different games at cycle "
+                            + agreed);
             assertEquals(-1, host.desyncCycle());
             assertEquals(-1, guest.desyncCycle());
         }
@@ -751,6 +813,69 @@ class LockstepTest {
                 "a machine one melee roll ahead of the others must be caught on the cycle"
                         + " it went wrong, not minutes later when the roll first moves a"
                         + " hit point");
+    }
+
+    @Test
+    @DisplayName("a machine one melee roll out of step is caught where it went out of step")
+    void anAsynchronousDivergenceIsReportedWhereItHappened() throws Exception {
+        // The claim the coverage check above cannot make. A player reported
+        // "desynchronised at cycle 2125" and nothing could be done with it,
+        // because the stream that decides every melee blow was outside the
+        // hash: the machines went on agreeing until the difference happened
+        // to move a hit point, so the cycle named was minutes past the one
+        // that broke. This drives two real peers, puts one of them a single
+        // asynchronous number ahead, and asks where the network says it
+        // happened.
+        World hostWorld = battlefield();
+        World guestWorld = battlefield();
+        UnitType hostType = hostWorld.units().getFirst().type();
+        UnitType guestType = guestWorld.units().getFirst().type();
+
+        try (NetworkSession hostSession = new NetworkSession(0, 0);
+                NetworkSession guestSession = new NetworkSession(1, 0)) {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            hostSession.addPeer(1, loopback, guestSession.localPort());
+            guestSession.addPeer(0, loopback, hostSession.localPort());
+            NetworkGame host = new NetworkGame(hostWorld, hostSession,
+                    new LockstepScheduler(2),
+                    new CommandApplier(hostWorld, List.of(hostType)), 0);
+            NetworkGame guest = new NetworkGame(guestWorld, guestSession,
+                    new LockstepScheduler(2),
+                    new CommandApplier(guestWorld, List.of(guestType)), 1);
+            host.start();
+            guest.start();
+
+            long wentWrongAt = -1;
+            int attempts = 0;
+            while (host.desyncCycle() < 0 && guest.desyncCycle() < 0 && attempts++ < 20_000) {
+                host.update();
+                guest.update();
+                if (wentWrongAt < 0 && guestWorld.cycle() >= 60
+                        && hostWorld.cycle() == guestWorld.cycle()) {
+                    // One number out of the asynchronous stream, which is
+                    // what a single melee blow costs.
+                    guestWorld.battleNetRandomForAi();
+                    wentWrongAt = guestWorld.cycle();
+                }
+            }
+
+            assertTrue(wentWrongAt > 0,
+                    "the two peers never reached the cycle this meant to break, so nothing"
+                            + " below is about a divergence");
+            NetworkGame noticed = host.desyncCycle() >= 0 ? host : guest;
+            assertTrue(noticed.desyncCycle() >= 0,
+                    "one machine drew a melee number the other did not and neither"
+                            + " noticed in " + attempts + " turns");
+            assertNotEquals(-1, noticed.desyncWorldCycle(),
+                    "the divergence was reported without the game cycle it happened on,"
+                            + " which is the number a player can look up");
+            long lateBy = noticed.desyncWorldCycle() - wentWrongAt;
+            assertTrue(lateBy >= 0 && lateBy <= 3 * LockstepScheduler.DEFAULT_CYCLES_PER_UPDATE,
+                    "the divergence happened at game cycle " + wentWrongAt + " and was"
+                            + " reported at " + noticed.desyncWorldCycle() + ", "
+                            + lateBy + " cycles later; it must be named where it happened"
+                            + " rather than whenever it first moved a hit point");
+        }
     }
 
     @Test

--- a/scripts/check-bne-network-gate.sh
+++ b/scripts/check-bne-network-gate.sh
@@ -23,12 +23,12 @@ observed = int(suite.attrib.get("tests", -1))
 skipped = int(suite.attrib.get("skipped", -1))
 failures = int(suite.attrib.get("failures", -1))
 errors = int(suite.attrib.get("errors", -1))
-if observed != 41 or skipped or failures or errors:
+if observed != 42 or skipped or failures or errors:
     raise SystemExit(
-        "LockstepTest: expected 41/0/0/0 tests/skips/failures/errors, "
+        "LockstepTest: expected 42/0/0/0 tests/skips/failures/errors, "
         f"got {observed}/{skipped}/{failures}/{errors}"
     )
-print("lockstep inventory: 41 pass, 0 skipped")
+print("lockstep inventory: 42 pass, 0 skipped")
 PY
 
 echo "network gate passed: independent peers converge through 1800 cycles and adverse UDP"

--- a/scripts/check-bne-network-gate.sh
+++ b/scripts/check-bne-network-gate.sh
@@ -23,12 +23,12 @@ observed = int(suite.attrib.get("tests", -1))
 skipped = int(suite.attrib.get("skipped", -1))
 failures = int(suite.attrib.get("failures", -1))
 errors = int(suite.attrib.get("errors", -1))
-if observed != 39 or skipped or failures or errors:
+if observed != 41 or skipped or failures or errors:
     raise SystemExit(
-        "LockstepTest: expected 39/0/0/0 tests/skips/failures/errors, "
+        "LockstepTest: expected 41/0/0/0 tests/skips/failures/errors, "
         f"got {observed}/{skipped}/{failures}/{errors}"
     )
-print("lockstep inventory: 39 pass, 0 skipped")
+print("lockstep inventory: 41 pass, 0 skipped")
 PY
 
 echo "network gate passed: independent peers converge through 1800 cycles and adverse UDP"
@@ -75,7 +75,7 @@ CHONKCRAFT_ASSET_PACK="${asset_pack}" \
   "${repo_root}/scripts/jbr/with-jbr-25.sh" java -cp "${classpath}" \
   net.chonkbase.chonkcraft.desktop.NetworkPeer \
   --lobby-host "${port}" --computer-player true --cycles 180 \
-  --game-template teams \
+  --game-template teams --game-speed fastest \
   >"${work}/host.log" 2>&1 &
 host_pid=$!
 sleep 1
@@ -143,6 +143,13 @@ require_log 'team-proof: human-allies=1 shared-human-allies=1 computer-enemies=1
   "${work}/host.log" "host-exact-team"
 require_log 'team-proof: human-allies=1 shared-human-allies=1 computer-enemies=1 active-computer-ais=1 attached-computer-ais=1' \
   "${work}/client.log" "client-exact-team"
+# The client is never told the speed on its command line. Reporting Fastest
+# proves the host's lobby choice crossed the wire and reached the seam the
+# desktop opens its simulation loop from.
+require_log 'game speed: Fastest 60 cycles a second' \
+  "${work}/host.log" "host-game-speed"
+require_log 'game speed: Fastest 60 cycles a second' \
+  "${work}/client.log" "client-game-speed"
 require_log 'finished: cycles=180' "${work}/host.log" "host-finish"
 require_log 'finished: cycles=180' "${work}/client.log" "client-finish"
 host_hash="$(sed -n 's/.*hash=\([0-9a-f]*\)$/\1/p' "${work}/host.log" | tail -1)"
@@ -151,7 +158,7 @@ if [[ -z "${host_hash}" || "${host_hash}" != "${client_hash}" ]]; then
   echo "real multiplayer worlds disagree: host=${host_hash}, client=${client_hash}" >&2
   exit 1
 fi
-echo "real multiplayer startup passed: transferred map, visible client frame, 180 cycles, hash ${host_hash}"
+echo "real multiplayer startup passed: transferred map, visible client frame, agreed Fastest speed, 180 cycles, hash ${host_hash}"
 
 # Opt in to the public service proof for deployment and release gates. This is
 # the same pair of real-data desktop processes as above, but room creation,

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -208,7 +208,7 @@ head2 "What a test run would exercise"
 
 if [[ "$wc2_ok" == 1 && "$pack_ok" == 1 && "$opus_ok" == 1 ]]; then
     printf '  All three external inputs are configured.\n'
-    printf '  Expect 3017 tests, normally 27 skipped, and about five minutes of wall time.\n'
+    printf '  Expect 3020 tests, normally 27 skipped, and about five minutes of wall time.\n'
     printf '  All three private playtest-save referees reduce that exact count to 24.\n'
     printf '  The expected skips cover display-only checks, an optional music\n'
     printf '  fixture, fixture-sensitive and custom-map checks, local playtest\n'
@@ -227,7 +227,7 @@ elif [[ "$wc2_ok" == 1 ]]; then
 else
     printf '  At least one external input is missing.\n'
     printf '  The suite will still report BUILD SUCCESS, having skipped most of itself:\n'
-    printf '  with no input at all, 1364 of 3017 tests skip.\n'
+    printf '  with no input at all, 1366 of 3020 tests skip.\n'
     printf '  That is not a passing run. See docs/development-setup.md.\n'
 fi
 

--- a/scripts/check-setup.sh
+++ b/scripts/check-setup.sh
@@ -208,7 +208,7 @@ head2 "What a test run would exercise"
 
 if [[ "$wc2_ok" == 1 && "$pack_ok" == 1 && "$opus_ok" == 1 ]]; then
     printf '  All three external inputs are configured.\n'
-    printf '  Expect 3012 tests, normally 27 skipped, and about five minutes of wall time.\n'
+    printf '  Expect 3017 tests, normally 27 skipped, and about five minutes of wall time.\n'
     printf '  All three private playtest-save referees reduce that exact count to 24.\n'
     printf '  The expected skips cover display-only checks, an optional music\n'
     printf '  fixture, fixture-sensitive and custom-map checks, local playtest\n'
@@ -227,7 +227,7 @@ elif [[ "$wc2_ok" == 1 ]]; then
 else
     printf '  At least one external input is missing.\n'
     printf '  The suite will still report BUILD SUCCESS, having skipped most of itself:\n'
-    printf '  with no input at all, 1363 of 3012 tests skip.\n'
+    printf '  with no input at all, 1364 of 3017 tests skip.\n'
     printf '  That is not a passing run. See docs/development-setup.md.\n'
 fi
 

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,8 +9,8 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. The configured authenticated
 floor and the measured data-free inventory are:
 
-    authenticated profile      3017 tests,   27 skipped
-    no external input          3017 tests, 1364 skipped
+    authenticated profile      3020 tests,   27 skipped
+    no external input          3020 tests, 1366 skipped
 
 Both can be green.
 
@@ -193,7 +193,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         #
         # Production service smoke is opt-in because an ordinary suite run
         # must not mutate or depend on the live room directory.
-        "engine": (2074, 1024),
+        "engine": (2075, 1024),
         # Seven authenticated multiplayer presentation referees cover shared
         # minimap sight, allied fog seams, restrained ping feedback, the retail
         # five-worker wood-click fan-out, team game-over presentation, and the
@@ -206,8 +206,11 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # data-free skips. The lobby game-speed batch adds three engine and
         # two desktop referees; only the one that opens the in-game menu needs
         # a pack for its fonts, so it alone joins this profile's skip
-        # inventory.
-        "desktop": (384, 281),
+        # inventory. The review that followed added a keyboard referee for
+        # the speed keys and a footer-geometry referee that measures its
+        # captions in the real game face; both need the pack and both
+        # deliberately join this profile's skip inventory.
+        "desktop": (386, 283),
         "matchmaker-server": (5, 1),
     },
     # Everything configured. What a developer with the game data should see on
@@ -250,10 +253,10 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # saves; the other fixture skips name custom maps absent from the
         # retail pack. The production service smoke runs in the deploy
         # workflow instead.
-        "engine": (2074, 7),
+        "engine": (2075, 7),
         # The classic hosted pack cannot run the explicit three-BNE-map
         # recording matrix, so that proof is a deliberate additional skip.
-        "desktop": (384, 8),
+        "desktop": (386, 8),
         "matchmaker-server": (5, 1),
     },
     # The same authenticated inputs as `full`, on a development machine that
@@ -267,8 +270,8 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (49, 0),
         "matchmaking": (2, 0),
-        "engine": (2074, 4),
-        "desktop": (384, 8),
+        "engine": (2075, 4),
+        "desktop": (386, 8),
         "matchmaker-server": (5, 1),
     },
     # The exact authenticated Battle.net Edition source archive, its matching
@@ -289,8 +292,8 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (49, 0),
         "matchmaking": (2, 0),
-        "engine": (2074, 12),
-        "desktop": (384, 6),
+        "engine": (2075, 12),
+        "desktop": (386, 6),
         "matchmaker-server": (5, 1),
     },
 }

--- a/scripts/ci/check-test-skips.py
+++ b/scripts/ci/check-test-skips.py
@@ -9,8 +9,8 @@ the Warcraft II data, an asset pack, or the Opus test vectors call JUnit
 and Maven reports BUILD SUCCESS either way. The configured authenticated
 floor and the measured data-free inventory are:
 
-    authenticated profile      3012 tests,   27 skipped
-    no external input          3012 tests, 1363 skipped
+    authenticated profile      3017 tests,   27 skipped
+    no external input          3017 tests, 1364 skipped
 
 Both can be green.
 
@@ -193,7 +193,7 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         #
         # Production service smoke is opt-in because an ordinary suite run
         # must not mutate or depend on the live room directory.
-        "engine": (2071, 1024),
+        "engine": (2074, 1024),
         # Seven authenticated multiplayer presentation referees cover shared
         # minimap sight, allied fog seams, restrained ping feedback, the retail
         # five-worker wood-click fan-out, team game-over presentation, and the
@@ -203,8 +203,11 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # BNE recording matrix likewise skips without its authenticated pack.
         # The sealed-null-target and explicit-unit-target physical transaction
         # referees need the Human 1 retail mission and add two deliberate
-        # data-free skips.
-        "desktop": (382, 280),
+        # data-free skips. The lobby game-speed batch adds three engine and
+        # two desktop referees; only the one that opens the in-game menu needs
+        # a pack for its fonts, so it alone joins this profile's skip
+        # inventory.
+        "desktop": (384, 281),
         "matchmaker-server": (5, 1),
     },
     # Everything configured. What a developer with the game data should see on
@@ -247,10 +250,10 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         # saves; the other fixture skips name custom maps absent from the
         # retail pack. The production service smoke runs in the deploy
         # workflow instead.
-        "engine": (2071, 7),
+        "engine": (2074, 7),
         # The classic hosted pack cannot run the explicit three-BNE-map
         # recording matrix, so that proof is a deliberate additional skip.
-        "desktop": (382, 8),
+        "desktop": (384, 8),
         "matchmaker-server": (5, 1),
     },
     # The same authenticated inputs as `full`, on a development machine that
@@ -264,8 +267,8 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (49, 0),
         "matchmaking": (2, 0),
-        "engine": (2071, 4),
-        "desktop": (382, 8),
+        "engine": (2074, 4),
+        "desktop": (384, 8),
         "matchmaker-server": (5, 1),
     },
     # The exact authenticated Battle.net Edition source archive, its matching
@@ -286,8 +289,8 @@ PROFILES: dict[str, dict[str, tuple[int, int]]] = {
         "extractor": (9, 0),
         "launcher": (49, 0),
         "matchmaking": (2, 0),
-        "engine": (2071, 12),
-        "desktop": (382, 6),
+        "engine": (2074, 12),
+        "desktop": (384, 6),
         "matchmaker-server": (5, 1),
     },
 }

--- a/tools/bne-harness/PARITY.md
+++ b/tools/bne-harness/PARITY.md
@@ -81,14 +81,14 @@ All runs use the pinned JBR 25 wrapper and BNE pack SHA-256
   and coarse orders, not raw sequence, extended player state, projectiles or
   mutable terrain.
 - **Playability:** all 18 lanes pass, including the 17-test control inventory,
-  117 movement checks, 65 projectile checks, 41 clean/adverse lockstep cases
+  117 movement checks, 65 projectile checks, 42 clean/adverse lockstep cases
   and real two-process startup. The Patrol regression resumes nine save points.
-- **Combined inventory:** pack plus Opus runs 3,017 tests: 2,602 pass,
+- **Combined inventory:** pack plus Opus runs 3,020 tests: 2,605 pass,
   93 known failures, zero errors, 322 skip. No new failure identity appears;
   master's corrected expansion Human 12 recovery-stage assertion now passes.
   Eleven fog tests that skipped on the earlier checkpoint now execute and pass.
-  Data-free runs 3,017 tests: 1,565 pass, 88 known failures, zero errors and
-  exactly 1,364 skips; its coverage and failure inventories match. Matching
+  Data-free runs 3,020 tests: 1,566 pass, 88 known failures, zero errors and
+  exactly 1,366 skips; its coverage and failure inventories match. Matching
   raw media was unavailable locally, so these are not the canonical 27-skip
   authenticated CI profile.
 - **Rendering integration:** the existing renderer completes its 400-unit

--- a/tools/bne-harness/PARITY.md
+++ b/tools/bne-harness/PARITY.md
@@ -81,14 +81,14 @@ All runs use the pinned JBR 25 wrapper and BNE pack SHA-256
   and coarse orders, not raw sequence, extended player state, projectiles or
   mutable terrain.
 - **Playability:** all 18 lanes pass, including the 17-test control inventory,
-  117 movement checks, 65 projectile checks, 39 clean/adverse lockstep cases
+  117 movement checks, 65 projectile checks, 41 clean/adverse lockstep cases
   and real two-process startup. The Patrol regression resumes nine save points.
-- **Combined inventory:** pack plus Opus runs 3,012 tests: 2,597 pass,
+- **Combined inventory:** pack plus Opus runs 3,017 tests: 2,602 pass,
   93 known failures, zero errors, 322 skip. No new failure identity appears;
   master's corrected expansion Human 12 recovery-stage assertion now passes.
   Eleven fog tests that skipped on the earlier checkpoint now execute and pass.
-  Data-free runs 3,012 tests: 1,561 pass, 88 known failures, zero errors and
-  exactly 1,363 skips; its coverage and failure inventories match. Matching
+  Data-free runs 3,017 tests: 1,565 pass, 88 known failures, zero errors and
+  exactly 1,364 skips; its coverage and failure inventories match. Matching
   raw media was unavailable locally, so these are not the canonical 27-skip
   authenticated CI profile.
 - **Rendering integration:** the existing renderer completes its 400-unit


### PR DESCRIPTION
Closes #16.

## What the report said

Two people trying a match saw `Desynchronised at cycle 2125 with player 1` and
asked whether changing the game speed had caused it.

## Root cause

**Speed is not the cause, and this is now executable.** Game speed is
`FixedStepLoop` hertz, purely local; lockstep gates every net cycle boundary
and nothing in the simulation reads wall-clock time, so a machine given more
turns spends the extra ones waiting.
`LockstepTest.anUnevenTempoBetweenPeersDoesNotChangeTheGame` runs one peer at
three cycles for every one of its opponent's through a battle and ends in the
same world.

**The real defect is that the desync detector could not localise.** `SyncHash`
covered the synchronized generator and not the asynchronous one. The
asynchronous one is where `World.battleNetMeleeDamage` rolls every melee blow
(`half + AsyncRand() % (half + 1)`), and where unit headings, idle wandering,
harvest approach, projectile motion and every computer-player decision come
from. A machine one draw ahead went on agreeing about the world until the
difference happened to move a hit point, so the cycle the network named was
minutes past the one that broke. `SCHEMA` goes 2 to 3.

The line also printed the raw slot index, so the message about player 2 called
them player 1.

I could not determine the reporter's actual first divergence: there is no
flight record from their machine. Every client keeps one in
`~/.chonkcraft/recordings`, and with both streams hashed the next report names
the cycle the divergence really happened on.

### Suspects cleared by probe, not by argument

- **Local click markers.** `World.markOrder` puts a green-cross missile into
  the shared missile list off the mouse thread. 20,000 cycles of real combat on
  Alamo, one world clicking and one quiet: byte-identical. It takes no pool
  slot and draws no number.
- **Mismatched asset packs.** Two packs here carry completely different
  `ai.bin` (BNE 22,377 bytes against Tides+BTDP 9,237, 83% of the shorter one
  differing). Same map, both packs, 20,000 cycles with a live computer player:
  identical hashes. Not this bug, though the lobby still checks the game build
  and map bytes and never the pack.

## The feature

The lobby settles the game speed: seven named steps, each a plain ratio of the
30 Hz simulation rate (Slowest 10 ... Normal 30 ... Fastest 60). Host-only,
carried in `STATE` and the `START` commit snapshot; lobby wire version 7 to 8.
Every machine opens its loop on it. The in-game control refuses in a network
game and names the host's setting, the way Pause already refuses -- a client
that slows only itself slows everybody's game by the same amount. The flight
record stores the agreed tempo, so `recorded_seconds` is still right at
Fastest.

`World.CYCLES_PER_SECOND` stays 30. This is tempo, not simulation.

Retail's lobby carries a nine-value game-speed byte at replay-header offset
`0x1F4` indexing a pacing table that has not been read out of the pinned
executable, so the seven steps and their rates are stated as this
implementation's own choice in the enum and in `docs/multiplayer-matchmaking.md`.

## Verification

- Network gate: lockstep inventory 39 to 41. The two-process lane now has the
  host pick Fastest and asserts the joiner -- never told a speed on its command
  line -- reports 60 cycles a second off its own running game. Confirmed the
  gate goes red when that seam is broken.
- Both new fixes confirmed to fail without them.
- Full suite, both profiles: 3,017 tests. Pack profile 93 failures, the
  documented pre-existing inventory, none in touched files. Data-free 88
  failures and 1,364 skips. Skip gate re-baselined by hand so its explanatory
  comments survived; `--write` strips them. Documentation gate green.

## Not fixed here

A Swamp-tileset map cannot load at all with a Tides+BTDP pack:
`GameData.TILESET_SOURCES` maps SWAMP to maindat entries 438/439/440, out of
range for that pack's 438-entry archive. It works with a BNE pack of 528
entries. Separate bug, found while probing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyEguJmmBG8nQy7MJbjm1c